### PR TITLE
WrenSec Builds - Phase #1 (for DS-SDK sustaining/3.0.0)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,14 @@
+export MAVEN_PACKAGE="opendj-sdk"
+export BINTRAY_PACKAGE="wrends-sdk"
+export JFROG_PACKAGE="org/forgerock/opendj"
+
+package_accept_release_tag() {
+  local tag_name="${1}"
+
+  if [ "${tag_name}" != "3.0.0" ]; then
+    echo "Skipping ${tag_name} since we only want to build 3.x right now."
+    return -1
+  else
+    return 0
+  fi
+}

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -35,7 +35,7 @@
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
     <artifactId>opendj-cli</artifactId>
-    <name>WrenDS CLI API</name>
+    <name>Wren:DS CLI API</name>
     <description>This module includes CLI API for implementing CLI applications.</description>
 
     <packaging>bundle</packaging>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2014-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -34,7 +35,7 @@
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
     <artifactId>opendj-cli</artifactId>
-    <name>OpenDJ CLI API</name>
+    <name>WrenDS CLI API</name>
     <description>This module includes CLI API for implementing CLI applications.</description>
 
     <packaging>bundle</packaging>

--- a/opendj-copyright-maven-plugin/pom.xml
+++ b/opendj-copyright-maven-plugin/pom.xml
@@ -36,7 +36,7 @@
     </parent>
 
     <artifactId>opendj-copyright-maven-plugin</artifactId>
-    <name>WrenDS Copyright Check Maven Plugin</name>
+    <name>Wren:DS Copyright Check Maven Plugin</name>
     <description>Checks Wren Security source file copyrights.</description>
 
     <packaging>maven-plugin</packaging>

--- a/opendj-copyright-maven-plugin/pom.xml
+++ b/opendj-copyright-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2015 ForgeRock AS.
+ !      Portions Copyright 2017 Wren Security.
  !
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-copyright-maven-plugin</artifactId>
-    <name>OpenDJ Copyright Check Maven Plugin</name>
-    <description>Checks ForgeRock source file copyrights.</description>
+    <name>WrenDS Copyright Check Maven Plugin</name>
+    <description>Checks Wren Security source file copyrights.</description>
 
     <packaging>maven-plugin</packaging>
 

--- a/opendj-copyright-maven-plugin/src/main/java/org/forgerock/maven/CopyrightAbstractMojo.java
+++ b/opendj-copyright-maven-plugin/src/main/java/org/forgerock/maven/CopyrightAbstractMojo.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.maven;
 
@@ -80,7 +81,7 @@ public abstract class CopyrightAbstractMojo extends AbstractMojo {
      * Copyright owner.
      * This string token must be present on the same line with 'copyright' keyword and the current year.
      */
-    @Parameter(required = true, defaultValue = "ForgeRock AS")
+    @Parameter(required = true, defaultValue = "Wren Security")
     private String copyrightOwnerToken;
 
     /** The path to the root of the scm local workspace to check. */

--- a/opendj-copyright-maven-plugin/src/main/java/org/forgerock/maven/UpdateCopyrightMojo.java
+++ b/opendj-copyright-maven-plugin/src/main/java/org/forgerock/maven/UpdateCopyrightMojo.java
@@ -81,11 +81,10 @@ import org.forgerock.util.Utils;
  *               Current year if there is no existing copyright line.
  *               If the copyright section already exists, the year will be updated as follow:
  *               <ul>
- *                  <li>OLD_YEAR => OLD_YEAR-CURRENT_YEAR</li>
- *                  <li>VERY_OLD_YEAR-OLD_YEAR => VERY_OLD_YEAR-CURRENT_YEAR</li>
- *              </ul></li>
+ *                  <li>{@code OLD_YEAR => OLD_YEAR-CURRENT_YEAR}</li>
+ *                  <li>{@code VERY_OLD_YEAR-OLD_YEAR => VERY_OLD_YEAR-CURRENT_YEAR}</li>
+ *               </ul></li>
  * </ul>
- * </p>
  * <p>
  * If no Wren Security copyrighted line is detected, the plugin will add according to the following
  * format
@@ -96,7 +95,7 @@ import org.forgerock.util.Utils;
  *              [COMMMENT_CHAR]* //This line references 0..N commented empty lines.
  *              ([COMMMENT_CHAR][oldCopyrightToken])*
  *              [indent][newPortionsCopyrightLabel] [YEAR] [forgerockCopyrightLabel]
- *              </pre></li><br>
+ *              </pre><br></li>
  *      <li> If there is no old copyright lines:
  *              <pre>
  *              [COMMMENT_CHAR][lineBeforeCopyrightRegExp]

--- a/opendj-copyright-maven-plugin/src/main/java/org/forgerock/maven/UpdateCopyrightMojo.java
+++ b/opendj-copyright-maven-plugin/src/main/java/org/forgerock/maven/UpdateCopyrightMojo.java
@@ -20,7 +20,8 @@
  *
  * CDDL HEADER END
  *
- *      Copyright 2015 ForgeRock AS
+ *      Copyright 2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.maven;
 
@@ -66,12 +67,12 @@ import org.forgerock.util.Utils;
  *  <li>lineBeforeCopyrightRegExp: Parameter regExp case insensitive
  *               Used by the plugin to start it's inspection for the copyright line.
  *               Next non blank commented lines after this lines must be
- *               old copyright owner lines or/and old ForgeRock copyright lines.</li>
+ *               old copyright owner lines or/and old Wren Security copyright lines.</li>
  *
  *  <li>oldCopyrightToken: Detected by plugin ('copyright' keyword case insensitive)
  *               If one line contains this token, the plugin will use
  *               the newPortionsCopyrightLabel instead of the newCopyrightLabel
- *               if there is no ForgeRock copyrighted line.</li>
+ *               if there is no Wren Security copyrighted line.</li>
  *
  *  <li>forgerockCopyrightRegExp: Parameter regExp case insensitive
  *               The regular expression which identifies a copyrighted line as a ForgeRock one.</li>
@@ -86,7 +87,8 @@ import org.forgerock.util.Utils;
  * </ul>
  * </p>
  * <p>
- * If no ForgeRock copyrighted line is detected, the plugin will add according to the following format
+ * If no Wren Security copyrighted line is detected, the plugin will add according to the following
+ * format
  * <ul>
  *      <li> If there is one or more old copyright lines:
  *              <pre>
@@ -339,7 +341,7 @@ public class UpdateCopyrightMojo extends CopyrightAbstractMojo {
     private String lineBeforeCopyrightRegExp;
 
     /** The regular expression which identifies a copyrighted line. */
-    @Parameter(required = true, defaultValue = "ForgeRock\\s+AS")
+    @Parameter(required = true, defaultValue = "Wren\\s+Security")
     private String forgerockCopyrightRegExp;
 
     /** Line to add if there is no existing copyright. */
@@ -350,8 +352,8 @@ public class UpdateCopyrightMojo extends CopyrightAbstractMojo {
     @Parameter(required = true, defaultValue = "Portions Copyright")
     private String newPortionsCopyrightLabel;
 
-    /** ForgeRock copyright label to print if a new (portions) copyright line is needed. */
-    @Parameter(required = true, defaultValue = "ForgeRock AS.")
+    /** Wren Security copyright label to print if a new (portions) copyright line is needed. */
+    @Parameter(required = true, defaultValue = "Wren Security.")
     private String forgeRockCopyrightLabel;
 
     /** A dry run will not change source code. It creates new files with '.tmp' extension. */

--- a/opendj-copyright-maven-plugin/src/test/java/org/forgerock/maven/UpdateCopyrightTestCase.java
+++ b/opendj-copyright-maven-plugin/src/test/java/org/forgerock/maven/UpdateCopyrightTestCase.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.maven;
 
@@ -83,13 +84,13 @@ public class UpdateCopyrightTestCase extends ForgeRockTestCase {
                 // New portion copyright string, New copyright start string, Copyright end regexp,
                 // New copyright end String
             { TEST_FOLDERS[0], "Portions\\s+Copyright\\s+\\[year\\]\\s+\\[name\\s+of\\s+copyright\\s+owner\\]",
-                1, 1, "Portions copyright", "Copyright", "ForgeRock\\s+AS", "ForgeRock AS." },
+                1, 1, "Portions copyright", "Copyright", "Wren\\s+Security", "Wren Security." },
             { TEST_FOLDERS[1], "CDDL\\s+HEADER\\s+END", 1, 6, "Portions Copyright", "Copyright",
-                "ForgeRock\\s+AS\\.", "ForgeRock AS." },
+                "Wren\\s+Security\\.", "Wren Security." },
             { TEST_FOLDERS[2],
                 "DO\\s+NOT\\s+ALTER\\s+OR\\s+REMOVE\\s+COPYRIGHT\\s+NOTICES\\s+OR\\s+THIS\\s+HEADER.", 1, 1,
-                "Portions Copyrighted", "Copyright (c)", "ForgeRock\\s+AS\\.",
-                "ForgeRock AS. All rights reserved." }
+                "Portions Copyrighted", "Copyright (c)", "Wren\\s+Security\\.",
+                "Wren Security. All rights reserved." }
         };
     }
 

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-1.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-1.txt
@@ -11,8 +11,8 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2012-2014 ForgeRock AS.
+ * Copyright 2012-2014 Wren Security.
  */
  
- MUST BE REMOVED: Copyright 2012-2014 ForgeRock AS.
- EXPECTED OUTPUT: Copyright 2012-YEAR ForgeRock AS.
+ MUST BE REMOVED: Copyright 2012-2014 Wren Security.
+ EXPECTED OUTPUT: Copyright 2012-YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-2.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-2.txt
@@ -11,9 +11,8 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2010 ForgeRock  AS.
+ * Copyright 2010 Wren  Security.
  */
  
-MUST BE REMOVED: Copyright 2010 ForgeRock  AS.
-EXPECTED OUTPUT: Copyright 2010-YEAR ForgeRock  AS.
- 
+MUST BE REMOVED: Copyright 2010 Wren  Security.
+EXPECTED OUTPUT: Copyright 2010-YEAR Wren  Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-3.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-3.txt
@@ -13,4 +13,4 @@
  *
  */
  
- EXPECTED OUTPUT: Copyright YEAR ForgeRock AS.
+ EXPECTED OUTPUT: Copyright YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-4.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-4.txt
@@ -14,4 +14,4 @@
  * Copyright 2010 Old Copyright Owner Inc.
  */
  
- EXPECTED OUTPUT: Portions copyright YEAR ForgeRock AS.
+ EXPECTED OUTPUT: Portions copyright YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-5.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-5.txt
@@ -15,4 +15,4 @@
  * copyright 2013-2014 Old copyright owner Inc.
  */
  
- EXPECTED OUTPUT: Portions copyright YEAR ForgeRock AS.
+ EXPECTED OUTPUT: Portions copyright YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-6.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openam-copyrights/openam-bad-copyright-6.txt
@@ -13,8 +13,8 @@
  *
  * Copyright 2008-2010 Very Old copyright owner Inc.
  * Portions copyright 2011-2012 Old copyright owner Inc.
- * Portions copyright 2013-2014 ForgeRock AS.
+ * Portions copyright 2013-2014 Wren Security.
  */
  
-MUST BE REMOVED: Portions copyright 2013-2014 ForgeRock AS.
-EXPECTED OUTPUT: Portions copyright 2013-YEAR ForgeRock AS.
+MUST BE REMOVED: Portions copyright 2013-2014 Wren Security.
+EXPECTED OUTPUT: Portions copyright 2013-YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-1.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-1.txt
@@ -21,8 +21,8 @@
  !
  ! CDDL HEADER END
  !
- !      Copyright   2012-2014 ForgeRock  AS.
+ !      Copyright   2012-2014 Wren  Security.
 -->
 
-MUST BE REMOVED: Copyright   2012-2014 ForgeRock  AS.
-EXPECTED OUTPUT: Copyright   2012-YEAR ForgeRock  AS.
+MUST BE REMOVED: Copyright   2012-2014 Wren  Security
+EXPECTED OUTPUT: Copyright   2012-YEAR Wren  Security

--- a/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-2.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-2.txt
@@ -20,8 +20,8 @@
  *
  * CDDL HEADER END
  *
- *      Copyright 2013 ForgeRock AS.
+ *      Copyright 2013 Wren Security.
  */
  
-MUST BE REMOVED: Copyright 2013 ForgeRock AS.
-EXPECTED OUTPUT: Copyright 2013-YEAR ForgeRock AS.
+MUST BE REMOVED: Copyright 2013 Wren Security.
+EXPECTED OUTPUT: Copyright 2013-YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-3.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-3.txt
@@ -22,4 +22,4 @@
  *
  */
  
-EXPECTED OUTPUT: Copyright YEAR ForgeRock AS.
+EXPECTED OUTPUT: Copyright YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-4.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-4.txt
@@ -24,4 +24,4 @@
  *
  */
  
-EXPECTED OUTPUT: Portions Copyright YEAR ForgeRock AS.
+EXPECTED OUTPUT: Portions Copyright YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-5.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-5.txt
@@ -24,4 +24,4 @@
  *      Copyright 2013-2014 Old copyright owner Inc.
  */
  
-EXPECTED OUTPUT: Portions Copyright YEAR ForgeRock AS.
+EXPECTED OUTPUT: Portions Copyright YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-6.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/opendj-copyrights/opendj-bad-copyright-6.txt
@@ -22,8 +22,8 @@
  *
  *      Copyright 2008-2010 Very Old copyright owner Inc.
  *      Portions Copyright 2011-2012 Old copyright owner Inc.
- *      Portions Copyright 2013-2014 ForgeRock AS.
+ *      Portions Copyright 2013-2014 Wren Security.
  */
  
-MUST BE REMOVED: Portions Copyright 2013-2014 ForgeRock AS.
-EXPECTED OUTPUT: Portions Copyright 2013-YEAR ForgeRock AS.
+MUST BE REMOVED: Portions Copyright 2013-2014 Wren Security.
+EXPECTED OUTPUT: Portions Copyright 2013-YEAR Wren Security.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-1.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-1.txt
@@ -1,7 +1,7 @@
 /*
  * DO NOT  ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2011-2014 ForgeRock AS. All rights reserved.
+ * Copyright (c) 2011-2014 Wren Security. All rights reserved.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -22,5 +22,5 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
  
-MUST BE REMOVED: Copyright (c) 2011-2014 ForgeRock AS. All rights reserved.
-EXPECTED OUTPUT: Copyright (c) 2011-YEAR ForgeRock AS. All rights reserved.
+MUST BE REMOVED: Copyright (c) 2011-2014 Wren Security. All rights reserved.
+EXPECTED OUTPUT: Copyright (c) 2011-YEAR Wren Security. All rights reserved.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-2.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-2.txt
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012 ForgeRock AS. All rights reserved.
+ * Copyright (c) 2012 Wren Security. All rights reserved.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -22,5 +22,5 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
  
-MUST BE REMOVED: Copyright (c) 2012 ForgeRock AS. All rights reserved.
-EXPECTED OUTPUT: Copyright (c) 2012-YEAR ForgeRock AS. All rights reserved.
+MUST BE REMOVED: Copyright (c) 2012 Wren Security. All rights reserved.
+EXPECTED OUTPUT: Copyright (c) 2012-YEAR Wren Security. All rights reserved.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-3.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-3.txt
@@ -21,4 +21,4 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
  
-EXPECTED OUTPUT: Copyright (c) YEAR ForgeRock AS. All rights reserved.
+EXPECTED OUTPUT: Copyright (c) YEAR Wren Security. All rights reserved.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-4.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-4.txt
@@ -22,4 +22,4 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
  
- EXPECTED OUTPUT: Portions Copyrighted YEAR ForgeRock AS. All rights reserved.
+ EXPECTED OUTPUT: Portions Copyrighted YEAR Wren Security. All rights reserved.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-5.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-5.txt
@@ -23,4 +23,4 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
  
-  EXPECTED OUTPUT: Portions Copyrighted YEAR ForgeRock AS. All rights reserved.
+  EXPECTED OUTPUT: Portions Copyrighted YEAR Wren Security. All rights reserved.

--- a/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-6.txt
+++ b/opendj-copyright-maven-plugin/src/test/resources/files/openidm-copyrights/openidm-bad-copyright-6.txt
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010-2011 Very Old Copyright Owner.
  * Portions Copyrighted 2012-2013 Old Copyright Owner.
- * Portions Copyrighted 2013-2014 ForgeRock  AS. All rights reserved.
+ * Portions Copyrighted 2013-2014 Wren  Security. All rights reserved.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -24,5 +24,5 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  */
  
-MUST BE REMOVED: Portions Copyrighted 2013-2014 ForgeRock  AS. All rights reserved.
-EXPECTED OUTPUT: Portions Copyrighted 2013-YEAR ForgeRock  AS. All rights reserved.
+MUST BE REMOVED: Portions Copyrighted 2013-2014 Wren  Security. All rights reserved.
+EXPECTED OUTPUT: Portions Copyrighted 2013-YEAR Wren  Security. All rights reserved.

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -36,7 +36,7 @@
     </parent>
 
     <artifactId>opendj-core</artifactId>
-    <name>WrenDS Core APIs</name>
+    <name>Wren:DS Core APIs</name>
     <description>
         This module provides the core APIs required for implementing LDAP Directory
         client and server applications. Unlike the SDK this module does not
@@ -245,7 +245,7 @@
             <id>forgerock-release</id>
 
             <properties>
-                <javadocTitle>WrenDS LDAP SDK ${project.version} API</javadocTitle>
+                <javadocTitle>Wren:DS LDAP SDK ${project.version} API</javadocTitle>
                 <timestamp>${maven.build.timestamp}</timestamp>
                 <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
             </properties>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS
+  !      Portions Copyright 2017 Wren Security.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,7 +36,7 @@
     </parent>
 
     <artifactId>opendj-core</artifactId>
-    <name>OpenDJ Core APIs</name>
+    <name>WrenDS Core APIs</name>
     <description>
         This module provides the core APIs required for implementing LDAP Directory
         client and server applications. Unlike the SDK this module does not
@@ -244,7 +245,7 @@
             <id>forgerock-release</id>
 
             <properties>
-                <javadocTitle>OpenDJ LDAP SDK ${project.version} API</javadocTitle>
+                <javadocTitle>WrenDS LDAP SDK ${project.version} API</javadocTitle>
                 <timestamp>${maven.build.timestamp}</timestamp>
                 <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
             </properties>
@@ -276,7 +277,7 @@
                                 </group>
 
                                 <group>
-                                    <title>ForgeRock Common Packages</title>
+                                    <title>Wren Security Common Packages</title>
                                     <packages>*</packages>
                                 </group>
                             </groups>
@@ -285,7 +286,7 @@
                             <windowtitle>${javadocTitle}</windowtitle>
                             <header>${javadocTitle}</header>
                             <footer>${javadocTitle}</footer>
-                            <bottom>Copyright 2011-${maven.build.timestamp} ForgeRock AS.</bottom>
+                            <bottom>Copyright 2011-2016 ForgeRock AS. Copyright 2017-${maven.build.timestamp} Wren Security.</bottom>
                             <links>
                                 <link>http://docs.oracle.com/javase/7/docs/api/</link>
                                 <link>http://www.slf4j.org/apidocs/</link>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -254,15 +254,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>javadoc-jar</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <includeDependencySources>true</includeDependencySources>
                             <includeTransitiveDependencySources>true</includeTransitiveDependencySources>

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteSequenceReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteSequenceReader.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
@@ -309,10 +310,10 @@ public final class ByteSequenceReader {
     /**
      * Relative read method for reading a compacted long value.
      * Compaction allows to reduce number of bytes needed to hold long types
-     * depending on its value (i.e: if value < 128, value will be encoded using one byte only).
-     * Reads the next bytes at this reader's current position, composing them into a long value
-     * according to big-endian byte order, and then increments the position by the size of the
-     * encoded long.
+     * depending on its value (i.e: if {@code value < 128}, value will be encoded using one byte
+     * only). Reads the next bytes at this reader's current position, composing them into a long
+     * value according to big-endian byte order, and then increments the position by the size of
+     * the encoded long.
      * Note that the maximum value of a compact long is 2^56.
      *
      * @return The long value at this reader's current position.
@@ -331,10 +332,10 @@ public final class ByteSequenceReader {
     /**
      * Relative read method for reading a compacted int value.
      * Compaction allows to reduce number of bytes needed to hold int types
-     * depending on its value (i.e: if value < 128, value will be encoded using one byte only).
-     * Reads the next bytes at this reader's current position, composing them into an int value
-     * according to big-endian byte order, and then increments the position by the size of the
-     * encoded int.
+     * depending on its value (i.e: if {@code value < 128}, value will be encoded using one byte
+     * only). Reads the next bytes at this reader's current position, composing them into an int
+     * value according to big-endian byte order, and then increments the position by the size of
+     * the encoded int.
      *
      * @return The int value at this reader's current position.
      * @throws IndexOutOfBoundsException

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteStringBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteStringBuilder.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2011-2015 ForgeRock AS
+ *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
@@ -309,15 +310,19 @@ public final class ByteStringBuilder implements ByteSequence {
      * Higher bits will be truncated. This method performs the equivalent of:
      *
      * <pre>
+     * {@code
      * int i = ...;
      * int i8bits = i & 0xFF;
      * // only use "i8bits"
+     * }
      * </pre>
      * OR
      * <pre>
+     * {@code
      * int i = ...;
      * byte b = (byte) i;
      * // only use "b"
+     * }
      * </pre>
      *
      * @param b
@@ -652,15 +657,19 @@ public final class ByteStringBuilder implements ByteSequence {
      * Higher bits will be truncated. This method performs the equivalent of:
      *
      * <pre>
+     * {@code
      * int i = ...;
      * int i16bits = i & 0xFFFF;
      * // only use "i16bits"
+     * }
      * </pre>
      * OR
      * <pre>
+     * {@code
      * int i = ...;
      * short s = (short) i;
      * // only use "s"
+     * }
      * </pre>
      *
      * @param i

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/CommonLDAPOptions.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/CommonLDAPOptions.java
@@ -21,6 +21,7 @@
  * CDDL HEADER END
  *
  *      Copyright 2014-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap;
@@ -94,12 +95,6 @@ abstract class CommonLDAPOptions {
      * <p>
      * The default setting is {@code -1} (disabled) and may be configured using
      * the {@code org.forgerock.opendj.io.linger} property.
-     *
-     * @param linger
-     *            The value of the {@link java.net.SocketOptions#SO_LINGER
-     *            SO_LINGER} socket option for new connections, or -1 if linger
-     *            should be disabled.
-     * @return A reference to this set of options.
      */
     public static final Option<Integer> SO_LINGER_IN_SECONDS = Option.withDefault(
         getIntProperty("org.forgerock.opendj.io.linger", -1));

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connection.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connection.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
- *      Portions Copyright 2011-2014 ForgeRock AS
+ *      Portions Copyright 2011-2014 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap;
@@ -55,13 +56,13 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * A connection with a Directory Server over which read and update operations
  * may be performed. See RFC 4511 for the LDAPv3 protocol specification and more
  * information about the types of operations defined in LDAP.
- * <p>
+ *
  * <h3>Operation processing</h3>
  * <p>
  * Operations may be performed synchronously or asynchronously depending on the
  * method chosen. Asynchronous methods can be identified by their {@code Async}
  * suffix.
- * <p>
+ *
  * <h4>Performing operations synchronously</h4>
  * <p>
  * Synchronous methods block until a response is received from the Directory
@@ -74,7 +75,7 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * another thread. This will cause the calling thread unblock and throw a
  * {@link CancelledResultException} whose cause is the underlying
  * {@link InterruptedException}.
- * <p>
+ *
  * <h4>Performing operations asynchronously</h4>
  * <p>
  * Asynchronous methods, identified by their {@code Async} suffix, are
@@ -125,7 +126,7 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * SearchResponseHandler handle = ...;
  * connection.search(request, handler);
  * </pre>
- * <p>
+ *
  * <h3>Closing connections</h3>
  * <p>
  * Applications must ensure that a connection is closed by calling
@@ -137,7 +138,7 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * connection. In this case all requests subsequent to the failure will fail
  * with an appropriate {@link LdapException} when their result is
  * retrieved.
- * <p>
+ *
  * <h3>Event notification</h3>
  * <p>
  * Applications can choose to be notified when a connection is closed by the

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connections.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connections.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
- *      Portions Copyright 2011-2015 ForgeRock AS
+ *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap;
@@ -369,16 +370,16 @@ public final class Connections {
      * connection factories. A round robin load balancing algorithm distributes connection requests across a list of
      * connection factories one at a time. When the end of the list is reached, the algorithm starts again from the
      * beginning.
-     * <p/>
+     * <p>
      * This algorithm is typically used for load-balancing <i>within</i> data centers, where load must be distributed
      * equally across multiple data sources. This algorithm contrasts with the {@link FailoverLoadBalancingAlgorithm}
      * which is used for load-balancing <i>between</i> data centers.
-     * <p/>
+     * <p>
      * If a problem occurs that temporarily prevents connections from being obtained for one of the connection
      * factories, then this algorithm automatically "fails over" to the next operational connection factory in the list.
      * If none of the connection factories are operational then a {@code ConnectionException} is returned to the
      * client.
-     * <p/>
+     * <p>
      * The implementation periodically attempts to connect to failed connection factories in order to determine if they
      * have become available again.
      *
@@ -399,21 +400,21 @@ public final class Connections {
      * Creates a new "fail-over" load-balance which will load-balance connections across the provided set of connection
      * factories. A fail-over load balancing algorithm provides fault tolerance across multiple underlying connection
      * factories.
-     * <p/>
+     * <p>
      * This algorithm is typically used for load-balancing <i>between</i> data centers, where there is preference to
      * always forward connection requests to the <i>closest available</i> data center. This algorithm contrasts with the
      * {@link RoundRobinLoadBalancingAlgorithm} which is used for load-balancing <i>within</i> a data center.
-     * <p/>
+     * <p>
      * This algorithm selects connection factories based on the order in which they were provided during construction.
      * More specifically, an attempt to obtain a connection factory will always return the <i>first operational</i>
      * connection factory in the list. Applications should, therefore, organize the connection factories such that the
      * <i>preferred</i> (usually the closest) connection factories appear before those which are less preferred.
-     * <p/>
+     * <p>
      * If a problem occurs that temporarily prevents connections from being obtained for one of the connection
      * factories, then this algorithm automatically "fails over" to the next operational connection factory in the list.
      * If none of the connection factories are operational then a {@code ConnectionException} is returned to the
      * client.
-     * <p/>
+     * <p>
      * The implementation periodically attempts to connect to failed connection factories in order to determine if they
      * have become available again.
      *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/DN.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/DN.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
- *      Portions copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
@@ -952,7 +953,7 @@ public final class DN implements Iterable<RDN>, Comparable<DN> {
      *   <li>lazily: the normalized value is computed only the first time it is needed.</li>
      * </ul>
      *
-     * @Deprecated This class will eventually be replaced by a compact implementation of a DN.
+     * @deprecated This class will eventually be replaced by a compact implementation of a DN.
      */
     public static final class CompactDn implements Comparable<CompactDn> {
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Filter.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Filter.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2009-2011 Sun Microsystems, Inc.
  *      Portions copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
@@ -58,12 +59,14 @@ import org.forgerock.util.Reject;
  * representation "{@code (&(cn=bjensen)(age>=21))}":
  *
  * <pre>
+ * {@code
  * import static org.forgerock.opendj.Filter.*;
  *
  * Filter filter = and(equality("cn", "bjensen"), greaterOrEqual("age", 21));
  *
  * // Alternatively use a filter template:
  * Filter filter = Filter.format("(&(cn=%s)(age>=%s))", "bjensen", 21);
+ * }
  * </pre>
  *
  * @see <a href="http://tools.ietf.org/html/rfc4511">RFC 4511 - Lightweight

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPConnectionFactory.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPConnectionFactory.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap;
@@ -684,8 +685,8 @@ public final class LDAPConnectionFactory extends CommonLDAPOptions implements Co
      *     <li> UNLOCKED(0) - the synchronizer may be acquired shared or exclusively
      *     <li> LOCKED_EXCLUSIVELY(-1) - the synchronizer is held exclusively and cannot be acquired shared or
      *          exclusively. An exclusive lock is held while a heart beat is in progress
-     *     <li> LOCKED_SHARED(>0) - the synchronizer is held shared and cannot be acquired exclusively. N shared locks
-     *          are held while N Bind or StartTLS operations are in progress.
+     *     <li> LOCKED_SHARED({@code >0}) - the synchronizer is held shared and cannot be acquired exclusively.
+                N shared locks are held while N Bind or StartTLS operations are in progress.
      * </ul>
      */
     private static final class Sync extends AbstractQueuedSynchronizer {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/RDN.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/RDN.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
  *      Portions copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap;
@@ -91,11 +92,13 @@ public final class RDN implements Iterable<AVA>, Comparable<RDN> {
      * construct a range whose contents is a sub-tree of entries:
      *
      * <pre>
+     * {@code
      * SortedMap<DN, Entry> entries = ...;
      * DN baseDN = ...;
      *
      * // Returns a map containing the baseDN and all of its subordinates.
      * SortedMap<DN,Entry> subtree = entries.subMap(baseDN, baseDN.child(RDN.maxValue));
+     * }
      * </pre>
      *
      * @return A constant containing a special RDN which is greater than any

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/SortKey.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/SortKey.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
@@ -54,13 +55,15 @@ import org.forgerock.util.Reject;
  * attribute as the sort key:
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  * SearchRequest request = ...;
  *
- * Comparator&lt;Entry> comparator = SortKey.comparator("cn");
- * Set&lt;SearchResultEntry>; results = new TreeSet&lt;SearchResultEntry>(comparator);
+ * Comparator<Entry> comparator = SortKey.comparator("cn");
+ * Set<SearchResultEntry> results = new TreeSet<SearchResultEntry>(comparator);
  *
  * connection.search(request, results);
+ * }
  * </pre>
  *
  * A sort key includes an attribute description and a boolean value that

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ADNotificationRequestControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ADNotificationRequestControl.java
@@ -20,7 +20,8 @@
  *
  * CDDL HEADER END
  *
- *      Copyright 2013 ForgeRock AS
+ *      Copyright 2013 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -30,9 +31,10 @@ import org.forgerock.opendj.ldap.ByteString;
  * The persistent search request control for Active Directory as defined by
  * Microsoft. This control allows a client to receive notification of changes
  * that occur in an Active Directory server.
- * <br/>
+ * <br>
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  *
  * SearchRequest request =
@@ -64,7 +66,7 @@ import org.forgerock.opendj.ldap.ByteString;
  *         reader.readReference(); //read and ignore reference
  *     }
  * }
- *
+ * }
  * </pre>
  *
  * @see <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa772153(v=vs.85).aspx">

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/Control.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/Control.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -39,14 +40,16 @@ import org.forgerock.opendj.ldap.ByteString;
  * OIDs, and then check for a match:
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
- * Collection&lt;String&gt; supported =
+ * Collection<String> supported =
  *     RootDSE.readRootDSE(connection).getSupportedControls();
  *
  * Control control = ...;
  * String OID = control.getOID();
  * if (supported != null && !supported.isEmpty() && supported.contains(OID)) {
  *     // The control is supported. Use it here...
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiredResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiredResponseControl.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
- *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyright 2014-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -43,6 +44,7 @@ import org.forgerock.util.Reject;
  * which is the string {@code "0"}.
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  * String DN = ...;
  * char[] password = ...;
@@ -61,6 +63,7 @@ import org.forgerock.util.Reject;
  *     } catch (DecodeException de) {
  *         // Failed to decode the response control.
  *     }
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiringResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiringResponseControl.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
- *      Portions copyright 2013-2015 ForgeRock AS
+ *      Portions copyright 2013-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -44,6 +45,7 @@ import org.forgerock.util.Reject;
  * expiration.
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  * String DN = ...;
  * char[] password = ...;
@@ -58,6 +60,7 @@ import org.forgerock.util.Reject;
  *     }
  * } catch (DecodeException de) {
  *     // Failed to decode the response control.
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyRequestControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyRequestControl.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
- *      Portions Copyright 2014 ForgeRock AS
+ *      Portions Copyright 2014 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -46,6 +47,7 @@ import org.forgerock.util.Reject;
  * policy response control when appropriate and with the proper data.
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  * String DN = ...;
  * char[] password = ...;
@@ -77,6 +79,7 @@ import org.forgerock.util.Reject;
  *     }
  * } catch (DecodeException e) {
  *     // Failed to decode the response control.
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyResponseControl.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2014 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -48,6 +49,7 @@ import org.forgerock.util.Reject;
  * draft-behera-ldap-password-policy.
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  * String DN = ...;
  * char[] password = ...;
@@ -79,6 +81,7 @@ import org.forgerock.util.Reject;
  *     }
  * } catch (DecodeException e) {
  *     // Failed to decode the response control.
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortRequestControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortRequestControl.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -65,6 +66,7 @@ import org.forgerock.util.Reject;
  * The following example demonstrates how to work with a server-side sort.
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  *
  * SearchRequest request = Requests.newSearchRequest(
@@ -80,6 +82,7 @@ import org.forgerock.util.Reject;
  *     // Entries are sorted.
  * } else {
  *     // Entries not sorted.
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortResponseControl.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
- *      Portions copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -59,6 +60,7 @@ import org.forgerock.util.Reject;
  * The following example demonstrates how to work with a server-side sort.
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
  *
  * SearchRequest request = Requests.newSearchRequest(
@@ -74,6 +76,7 @@ import org.forgerock.util.Reject;
  *     // Entries are sorted.
  * } else {
  *     // Entries not sorted.
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/ExtendedRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/ExtendedRequest.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -47,14 +48,16 @@ import org.forgerock.opendj.ldap.responses.ExtendedResultDecoder;
  * extension OIDs, and then check for a match. For example:
  *
  * <pre>
+ * {@code
  * Connection connection = ...;
- * Collection&lt;String&gt; supported =
+ * Collection<String> supported =
  *     RootDSE.readRootDSE(connection).getSupportedExtendedOperations();
  *
  * ExtendedRequest extension = ...;
  * String OID = extension.getOID();
  * if (supported != null && !supported.isEmpty() && supported.contains(OID)) {
  *     // The extension is supported. Use it here...
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PasswordModifyExtendedRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PasswordModifyExtendedRequest.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
- *      Portions copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -46,7 +47,8 @@ import org.forgerock.opendj.ldap.responses.PasswordModifyExtendedResult;
  * well as for generating a new password if none was provided.
  *
  * <pre>
- * String userIdentity = ...; // For example, u:&lt;uid> or dn:&lt;DN>
+ * {@code
+ * String userIdentity = ...; // For example, u:<uid> or dn:<DN>
  * char[] oldPassword = ...;
  * char[] newPassword = ...;
  * Connection connection = ...;
@@ -62,6 +64,7 @@ import org.forgerock.opendj.ldap.responses.PasswordModifyExtendedResult;
  *     // Changed password
  * } else {
  *     // Use result to diagnose error.
+ * }
  * }
  * </pre>
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequest.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
- *      Portions Copyright 2011-2014 ForgeRock AS
+ *      Portions Copyright 2011-2014 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -45,8 +46,9 @@ import org.forgerock.opendj.ldap.controls.ControlDecoder;
  * authorization ID, or {@code authzId}, as defined in RFC 4513 section 5.2.1.8.
  *
  * <pre>
- * String authcid = ...;        // Authentication ID, e.g. dn:&lt;dn>, u:&lt;uid>
- * String authzid = ...;        // Authorization ID, e.g. dn:&lt;dn>, u:&lt;uid>
+ * {@code
+ * String authcid = ...;        // Authentication ID, e.g. dn:<dn>, u:<uid>
+ * String authzid = ...;        // Authorization ID, e.g. dn:<dn>, u:<uid>
  * char[] password = ...;
  * Connection connection = ...; // Use StartTLS to protect the request
  *
@@ -56,6 +58,7 @@ import org.forgerock.opendj.ldap.controls.ControlDecoder;
  *
  * connection.bind(request);
  * // Authenticated if the connection succeeds
+ * }
  * </pre>
  *
  * @see <a href="http://tools.ietf.org/html/rfc4616">RFC 4616 - The PLAIN Simple

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/SASLBindRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/SASLBindRequest.java
@@ -22,7 +22,8 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions Copyright 2014 ForgeRock AS
+ *      Portions Copyright 2014 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -40,7 +41,7 @@ import org.forgerock.opendj.ldap.controls.ControlDecoder;
  * authenticate using one of the SASL authentication methods defined in RFC
  * 4513.
  * <p>
- * <TODO>finish doc.
+ * TODO: finish doc.
  *
  * @see <a href="http://tools.ietf.org/html/rfc4513#section-5.2.1.8">RFC 4513 -
  *      SASL Authorization Identities (authzId) </a>

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/Schema.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/Schema.java
@@ -22,8 +22,9 @@
  *
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
- *      Portions Copyright 2011-2015 ForgeRock AS
- *      Portions Copyright 2014 Manuel Gaupp
+ *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2014 Manuel Gaupp.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -1016,7 +1017,7 @@ public final class Schema {
      * <p>
      * This implementation first reads the {@code subschemaSubentry} attribute
      * of the entry in order to identify the schema and then invokes
-     * {@link #readSchemaAsync(Connection, DN, ResultHandler)} to read the
+     * {@link #readSchemaAsync(Connection, DN)} to read the
      * schema.
      *
      * @param connection

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LDAPConnectionImpl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LDAPConnectionImpl.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.ldap.spi;
 
@@ -126,7 +127,7 @@ public interface LDAPConnectionImpl extends Closeable {
 
     /**
      * Releases any resources associated with this connection.
-     * <p/>
+     * <p>
      * Calling {@code close} on a connection that is already closed has no effect.
      * @see org.forgerock.opendj.ldap.Connection#close()
      */
@@ -135,7 +136,7 @@ public interface LDAPConnectionImpl extends Closeable {
 
     /**
      * Releases any resources associated with this connection.
-     * <p/>
+     * <p>
      * Calling {@code close} on a connection that is already closed has no effect.
      *
      * @param request

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIF.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIF.java
@@ -20,7 +20,8 @@
  *
  * CDDL HEADER END
  *
- *      Copyright 2011-2015 ForgeRock AS
+ *      Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.ldif;
@@ -295,6 +296,7 @@ public final class LDIF {
      * <p>
      * Sample usage:
      * <pre>
+     * {@code
      * List<Entry> smiths = TestCaseUtils.makeEntries(
      *   "dn: cn=John Smith,dc=example,dc=com",
      *   "objectclass: inetorgperson",
@@ -307,6 +309,7 @@ public final class LDIF {
      *   "cn: Jane Smith",
      *   "sn: Smith",
      *   "givenname: Jane");
+     * }
      * </pre>
      * @param ldifLines
      *          LDIF lines that contains entries definition.

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -37,7 +38,7 @@
     <artifactId>opendj-doc-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
-    <name>OpenDJ Doc Helper Maven Plugin</name>
+    <name>WrenDS Doc Helper Maven Plugin</name>
     <description>Helps to build generated documentation sources.</description>
 
     <properties>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
     <artifactId>opendj-doc-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
-    <name>WrenDS Doc Helper Maven Plugin</name>
+    <name>Wren:DS Doc Helper Maven Plugin</name>
     <description>Helps to build generated documentation sources.</description>
 
     <properties>

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/CommandLineTool.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/CommandLineTool.java
@@ -22,13 +22,14 @@
  *
  *
  *      Copyright 2015 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.opendj.maven.doc;
 
 import java.util.List;
 
 /**
- * Represents a command-line tool as used in the configuration for {@see GenerateRefEntriesMojo}.
+ * Represents a command-line tool as used in the configuration for {@link GenerateRefEntriesMojo}.
  * <br>
  * Command-line tools are associated with a script name, the Java class of the tool,
  * and a list of relative paths to hand-written files for trailing sections.

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -36,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-grizzly</artifactId>
-    <name>WrenDS Grizzly Transport Provider</name>
-    <description>This module includes a Grizzly based network transport provider for WrenDS.</description>
+    <name>Wren:DS Grizzly Transport Provider</name>
+    <description>This module includes a Grizzly based network transport provider for Wren:DS.</description>
 
     <packaging>bundle</packaging>
 

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -21,7 +21,8 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2013-2015 ForgeRock AS
+  !      Copyright 2013-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-grizzly</artifactId>
-    <name>OpenDJ Grizzly Transport Provider</name>
-    <description>This module includes a Grizzly based network transport provider for OpenDJ.</description>
+    <name>WrenDS Grizzly Transport Provider</name>
+    <description>This module includes a Grizzly based network transport provider for WrenDS.</description>
 
     <packaging>bundle</packaging>
 

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -36,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-ldap-sdk-examples</artifactId>
-    <name>WrenDS SDK Examples</name>
-    <description>Examples illustrating usage of the WrenDS LDAP SDK</description>
+    <name>Wren:DS SDK Examples</name>
+    <description>Examples illustrating usage of the Wren:DS LDAP SDK</description>
 
     <dependencies>
         <dependency>

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-ldap-sdk-examples</artifactId>
-    <name>OpenDJ SDK Examples</name>
-    <description>Examples illustrating usage of the OpenDJ LDAP SDK</description>
+    <name>WrenDS SDK Examples</name>
+    <description>Examples illustrating usage of the WrenDS LDAP SDK</description>
 
     <dependencies>
         <dependency>

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -36,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-ldap-toolkit</artifactId>
-    <name>WrenDS SDK Toolkit</name>
-    <description>This module includes LDAP command line tools based on the WrenDS LDAP SDK.</description>
+    <name>Wren:DS SDK Toolkit</name>
+    <description>This module includes LDAP command line tools based on the Wren:DS LDAP SDK.</description>
 
     <packaging>jar</packaging>
 

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -22,6 +22,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2011-2016 ForgeRock AS.
+ !      Portions Copyright 2017 Wren Security.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,8 +36,8 @@
     </parent>
 
     <artifactId>opendj-ldap-toolkit</artifactId>
-    <name>OpenDJ SDK Toolkit</name>
-    <description>This module includes LDAP command line tools based on the OpenDJ LDAP SDK.</description>
+    <name>WrenDS SDK Toolkit</name>
+    <description>This module includes LDAP command line tools based on the WrenDS LDAP SDK.</description>
 
     <packaging>jar</packaging>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>opendj-rest2ldap</artifactId>
-    <name>WrenDS Commons REST Adapter</name>
+    <name>Wren:DS Commons REST Adapter</name>
     <description>This module includes APIs for accessing LDAP repositories using commons REST.</description>
 
     <packaging>bundle</packaging>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -13,6 +13,7 @@
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
   ! Copyright 2012-2015 ForgeRock AS.
+  ! Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -26,7 +27,7 @@
     </parent>
 
     <artifactId>opendj-rest2ldap</artifactId>
-    <name>OpenDJ Commons REST Adapter</name>
+    <name>WrenDS Commons REST Adapter</name>
     <description>This module includes APIs for accessing LDAP repositories using commons REST.</description>
 
     <packaging>bundle</packaging>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -39,7 +39,7 @@
 
     <packaging>pom</packaging>
 
-    <name>WrenDS SDK Parent</name>
+    <name>Wren:DS SDK Parent</name>
     <description>
         This group module provides a complete LDAP SDK for developing LDAP Directory client and server applications.
     </description>
@@ -64,7 +64,7 @@
         <!-- OSGi bundles properties -->
         <opendj.osgi.import.additional />
         <!--
-         | Use provide:=true to disallow mixing WrenDS and ForgeRock resource versions.
+         | Use provide:=true to disallow mixing Wren:DS and ForgeRock resource versions.
          | it change the version policy from == + to == =+  [2.0,3) [2.0,2.1)
         -->
         <opendj.osgi.import>
@@ -85,7 +85,7 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- WrenDS SDK -->
+            <!-- Wren:DS SDK -->
             <dependency>
                 <groupId>org.forgerock.opendj</groupId>
                 <artifactId>opendj-core</artifactId>
@@ -289,7 +289,7 @@
                     <artifactId>forgerock-doc-maven-plugin</artifactId>
                     <version>${forgerock-doc-plugin.version}</version>
                     <configuration>
-                        <projectName>WrenDS</projectName>
+                        <projectName>Wren:DS</projectName>
                         <projectVersion>${project.version}</projectVersion>
                         <releaseVersion>${project.version}</releaseVersion>
                         <googleAnalyticsId>UA-23412190-8</googleAnalyticsId>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -38,7 +39,7 @@
 
     <packaging>pom</packaging>
 
-    <name>OpenDJ SDK Parent</name>
+    <name>WrenDS SDK Parent</name>
     <description>
         This group module provides a complete LDAP SDK for developing LDAP Directory client and server applications.
     </description>
@@ -63,7 +64,7 @@
         <!-- OSGi bundles properties -->
         <opendj.osgi.import.additional />
         <!--
-         | Use provide:=true to disallow mixing OpenDJ and ForgeRock resource versions.
+         | Use provide:=true to disallow mixing WrenDS and ForgeRock resource versions.
          | it change the version policy from == + to == =+  [2.0,3) [2.0,2.1)
         -->
         <opendj.osgi.import>
@@ -84,7 +85,7 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- OpenDJ SDK -->
+            <!-- WrenDS SDK -->
             <dependency>
                 <groupId>org.forgerock.opendj</groupId>
                 <artifactId>opendj-core</artifactId>
@@ -300,7 +301,7 @@
                     <artifactId>forgerock-doc-maven-plugin</artifactId>
                     <version>${forgerock-doc-plugin.version}</version>
                     <configuration>
-                        <projectName>OpenDJ</projectName>
+                        <projectName>WrenDS</projectName>
                         <projectVersion>${project.version}</projectVersion>
                         <releaseVersion>${project.version}</releaseVersion>
                         <googleAnalyticsId>UA-23412190-8</googleAnalyticsId>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -240,18 +240,6 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <configuration>
                         <locales>en</locales>

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
     </issueManagement>
 
     <scm>
-        <url>https://github.com/WrenSecurity/wrends</url>
-        <connection>scm:git:git://github.com/WrenSecurity/wrends.git</connection>
-        <developerConnection>scm:git:git@github.com:WrenSecurity/wrends.git</developerConnection>
+        <url>https://github.com/WrenSecurity/wrends-sdk</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrends-sdk.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrends-sdk.git</developerConnection>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
 
     <packaging>pom</packaging>
 
-    <name>WrenDS SDK BOM</name>
-    <description>WrenDS BOM.
-        Provides a list of WrenDS dependencies
+    <name>Wren:DS SDK BOM</name>
+    <description>Wren:DS BOM.
+        Provides a list of Wren:DS dependencies
         which are known to be compatible with each other.
     </description>
     <inceptionYear>2017</inceptionYear>
@@ -50,13 +50,13 @@
 
     <issueManagement>
         <system>GitHub Issues</system>
-        <url>https://github.com/WrenSecurity/wrends/issues</url>
+        <url>https://github.com/WrenSecurity/WrenDS/issues</url>
     </issueManagement>
 
     <scm>
-        <url>https://github.com/WrenSecurity/wrends-sdk</url>
-        <connection>scm:git:git://github.com/WrenSecurity/wrends-sdk.git</connection>
-        <developerConnection>scm:git:git@github.com:WrenSecurity/wrends-sdk.git</developerConnection>
+        <url>https://github.com/WrenSecurity/WrenDS-SDK</url>
+        <connection>scm:git:git://github.com/WrenSecurity/WrenDS-SDK.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/WrenDS-SDK.git</developerConnection>
     </scm>
 
     <licenses>
@@ -64,7 +64,7 @@
             <name>CDDL-1.0</name>
             <url>http://www.opensource.org/licenses/CDDL-1.0</url>
             <comments>Common Development and Distribution License (CDDL) 1.0.
-                This license applies to WrenDS source code as indicated in the
+                This license applies to Wren:DS source code as indicated in the
                 source files.
             </comments>
             <distribution>repo</distribution>
@@ -149,7 +149,7 @@
             </dependency>
 
 
-            <!-- WrenDS SDK -->
+            <!-- Wren:DS SDK -->
             <dependency>
                 <groupId>org.forgerock.opendj</groupId>
                 <artifactId>opendj-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,8 @@
     <properties>
         <opendj.sdk.version>3.0.0</opendj.sdk.version>
         <i18n-framework.version>1.4.3-SNAPSHOT</i18n-framework.version>
+        <!-- FIXME: Needed for POM-less org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0 -->
+        <pgpVerifyPluginVersion>1.2.0-SNAPSHOT</pgpVerifyPluginVersion>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -39,73 +40,31 @@
 
     <packaging>pom</packaging>
 
-    <name>OpenDJ SDK BOM</name>
-    <description>OpenDJ BOM.
-        Provides a list of OpenDJ dependencies
+    <name>WrenDS SDK BOM</name>
+    <description>WrenDS BOM.
+        Provides a list of WrenDS dependencies
         which are known to be compatible with each other.
     </description>
-    <inceptionYear>2011</inceptionYear>
-    <url>http://opendj.forgerock.org</url>
+    <inceptionYear>2017</inceptionYear>
+    <url>http://wrensecurity.org</url>
 
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/OPENDJSDK</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrends/issues</url>
     </issueManagement>
 
-    <mailingLists>
-        <mailingList>
-            <name>OpenDJ Users Mailing List</name>
-            <archive>http://lists.forgerock.org/pipermail/opendj/</archive>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</unsubscribe>
-            <post>opendj@forgerock.org</post>
-        </mailingList>
-
-        <mailingList>
-            <name>OpenDJ Developers Mailing List</name>
-            <archive>http://lists.forgerock.org/pipermail/opendj-dev/</archive>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj-dev/</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj-dev/</unsubscribe>
-            <post>opendj-dev@forgerock.org</post>
-        </mailingList>
-    </mailingLists>
-
     <scm>
-        <url>https://stash.forgerock.org/projects/OPENDJ/repos/opendj-sdk/browse</url>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj-sdk.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj-sdk.git</developerConnection>
-        <tag>3.0.0</tag>
+        <url>https://github.com/WrenSecurity/wrends</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrends.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrends.git</developerConnection>
     </scm>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/OpenDJ/job/OpenDJ%20-%20SDK%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>opendj-dev@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
-
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>OpenDJ Community</name>
-            <url>${site.distribution.url}</url>
-        </site>
-    </distributionManagement>
 
     <licenses>
         <license>
             <name>CDDL-1.0</name>
             <url>http://www.opensource.org/licenses/CDDL-1.0</url>
             <comments>Common Development and Distribution License (CDDL) 1.0.
-                This license applies to OpenDJ source code as indicated in the
+                This license applies to WrenDS source code as indicated in the
                 source files.
             </comments>
             <distribution>repo</distribution>
@@ -114,18 +73,28 @@
 
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
 
         <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -148,17 +117,13 @@
     </modules>
 
     <properties>
-        <site.distribution.url>
-            scp://community.internal.forgerock.com/var/www/vhosts/opendj.forgerock.org/httpdocs
-        </site.distribution.url>
-
         <opendj.sdk.version>3.0.0</opendj.sdk.version>
         <i18n-framework.version>1.4.2</i18n-framework.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- ForgeRock BOM -->
+            <!-- Wren Security BOM -->
             <dependency>
                 <groupId>org.forgerock.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
@@ -181,7 +146,7 @@
             </dependency>
 
 
-            <!-- OpenDJ SDK -->
+            <!-- WrenDS SDK -->
             <dependency>
                 <groupId>org.forgerock.opendj</groupId>
                 <artifactId>opendj-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,13 +112,31 @@
         </repository>
     </repositories>
 
+    <!-- may be temporary: probably belongs in parent POM -->
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Plugin Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+    <!-- /may be temporary -->
+
     <modules>
         <module>opendj-sdk-parent</module>
     </modules>
 
     <properties>
         <opendj.sdk.version>3.0.0</opendj.sdk.version>
-        <i18n-framework.version>1.4.2</i18n-framework.version>
+        <i18n-framework.version>1.4.3-SNAPSHOT</i18n-framework.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,20 @@
     </pluginRepositories>
     <!-- /may be temporary -->
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}/wrends/;publish=1</url>
+        </snapshotRepository>
+
+        <repository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}/wrends/;publish=1</url>
+        </repository>
+    </distributionManagement>
+
     <modules>
         <module>opendj-sdk-parent</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,11 @@
     </licenses>
 
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
             <snapshots>
                 <enabled>false</enabled>
@@ -83,20 +84,6 @@
 
             <releases>
                 <enabled>true</enabled>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>bintray-wrensecurity-snapshots</id>
-            <name>Wren Security Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
             </releases>
         </repository>
 
@@ -112,35 +99,17 @@
         </repository>
     </repositories>
 
-    <!-- may be temporary: probably belongs in parent POM -->
-    <pluginRepositories>
-        <pluginRepository>
-            <id>bintray-wrensecurity-snapshots</id>
-            <name>Wren Security Plugin Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
-    <!-- /may be temporary -->
-
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}/wrends/;publish=1</url>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}/wrends/;publish=1</url>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
- modifies the OpenDJ / Wren:DS SDK POMs to build using Wren's repos.
- updates branding to call this Wren:DS instead of OpenDJ.
- fixes Javadoc generation when using Java 8+.
- modifies the OpenDJ copyright tool to enforce Wren Security copyrights instead of ForgeRock copyrights.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.

don't be alarmed about the changes to the "headers" in the test input data for the copyright plug-in -- I am not actually modifying CDDL copyrights. it's source data for the test, since the plugin works with headers.