### PR TITLE
Switch to i18n-framework 1.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 
     <properties>
         <opendj.sdk.version>3.0.0</opendj.sdk.version>
-        <i18n-framework.version>1.4.3-SNAPSHOT</i18n-framework.version>
+        <i18n-framework.version>1.4.3</i18n-framework.version>
         <!-- FIXME: Needed for POM-less org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0 -->
         <pgpVerifyPluginVersion>1.2.0-SNAPSHOT</pgpVerifyPluginVersion>
     </properties>


### PR DESCRIPTION
depends on https://github.com/WrenSecurity/wrensec-i18n-framework/pull/5.