### PR TITLE
Upgrade to pgpverify 1.2.0-wren1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,6 @@
     <properties>
         <opendj.sdk.version>3.0.0</opendj.sdk.version>
         <i18n-framework.version>1.4.3</i18n-framework.version>
-        <!-- FIXME: Needed for POM-less org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0 -->
-        <pgpVerifyPluginVersion>1.2.0-SNAPSHOT</pgpVerifyPluginVersion>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
the parent POM now specifies 1.2.0-wren1.
this free us from having to maintain PGP signatures for the JDK `tools.jar`.