### PR TITLE
Upgrade to Wren Security Parent 2.2.0 and Prepare a 3.0.1 Release

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,14 +1,1 @@
 export MAVEN_PACKAGE="opendj-sdk"
-export BINTRAY_PACKAGE="wrends-sdk"
-export JFROG_PACKAGE="org/forgerock/opendj"
-
-package_accept_release_tag() {
-  local tag_name="${1}"
-
-  if [ "${tag_name}" != "3.0.0" ]; then
-    echo "Skipping ${tag_name} since we only want to build 3.x right now."
-    return -1
-  else
-    return 0
-  fi
-}

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -21,7 +21,7 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2014-2015 ForgeRock AS.
+  !      Copyright 2014-2016 ForgeRock AS.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
     <artifactId>opendj-cli</artifactId>

--- a/opendj-copyright-maven-plugin/pom.xml
+++ b/opendj-copyright-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
  !
  ! CDDL HEADER END
  !
- !      Copyright 2015 ForgeRock AS.
+ !      Copyright 2015-2016 ForgeRock AS.
  !
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-copyright-maven-plugin/pom.xml
+++ b/opendj-copyright-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -21,7 +21,7 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2011-2015 ForgeRock AS
+  !      Copyright 2011-2016 ForgeRock AS
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/AbstractSubstringMatchingRuleImpl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/AbstractSubstringMatchingRuleImpl.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2014-2015 ForgeRock AS
+ *      Portions copyright 2014-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -195,12 +195,13 @@ abstract class AbstractSubstringMatchingRuleImpl extends AbstractMatchingRuleImp
 
         private <T> void substringMatch(final IndexQueryFactory<T> factory, final ByteString normSubstring,
                 final Collection<T> subqueries) {
-            int substrLength = factory.getIndexingOptions().substringKeySize();
+            final int substrLength = factory.getIndexingOptions().substringKeySize();
+            final String indexId = substringIndexId + ":" + substrLength;
 
             // There are two cases, depending on whether the user-provided
             // substring is smaller than the configured index substring length or not.
             if (normSubstring.length() < substrLength) {
-                subqueries.add(rangeMatch(factory, substringIndexId, normSubstring));
+                subqueries.add(rangeMatch(factory, indexId, normSubstring));
             } else {
                 // Break the value up into fragments of length equal to the
                 // index substring length, and read those keys.
@@ -216,7 +217,7 @@ abstract class AbstractSubstringMatchingRuleImpl extends AbstractMatchingRuleImp
                 }
 
                 for (ByteSequence key : substringKeys) {
-                    subqueries.add(factory.createExactMatchQuery(substringIndexId, key));
+                    subqueries.add(factory.createExactMatchQuery(indexId, key));
                 }
             }
         }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/AttributeType.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/AttributeType.java
@@ -122,6 +122,18 @@ public final class AttributeType extends SchemaElement implements Comparable<Att
         }
 
         /**
+         * Adds this attribute type to the schema, overwriting any existing attribute type
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any attribute type with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
+        }
+
+        /**
          * Sets the matching rule that should be used for approximate matching
          * with this attribute type.
          *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/AttributeType.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/AttributeType.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2011-2015 ForgeRock AS.
+ *      Portions copyright 2011-2016 ForgeRock AS.
  */
 
 package org.forgerock.opendj.ldap.schema;
@@ -30,6 +30,7 @@ package org.forgerock.opendj.ldap.schema;
 import static java.util.Arrays.*;
 
 import static org.forgerock.opendj.ldap.schema.SchemaConstants.*;
+import static org.forgerock.opendj.ldap.schema.SchemaOptions.ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX;
 import static org.forgerock.opendj.ldap.schema.SchemaUtils.*;
 
 import static com.forgerock.opendj.ldap.CoreMessages.*;
@@ -108,7 +109,7 @@ public final class AttributeType extends SchemaElement implements Comparable<Att
          *             numeric OID.
          */
         public SchemaBuilder addToSchema() {
-            return getSchemaBuilder().addAttributeType(new AttributeType(this), false);
+            return addToSchema(false);
         }
 
         /**
@@ -118,19 +119,11 @@ public final class AttributeType extends SchemaElement implements Comparable<Att
          * @return The parent schema builder.
          */
         public SchemaBuilder addToSchemaOverwrite() {
-            return getSchemaBuilder().addAttributeType(new AttributeType(this), true);
+            return addToSchema(true);
         }
 
-        /**
-         * Adds this attribute type to the schema, overwriting any existing attribute type
-         * with the same numeric OID if the overwrite parameter is set to {@code true}.
-         *
-         * @param overwrite
-         *            {@code true} if any attribute type with the same OID should be overwritten.
-         * @return The parent schema builder.
-         */
         SchemaBuilder addToSchema(final boolean overwrite) {
-            return overwrite ? addToSchemaOverwrite() : addToSchema();
+            return getSchemaBuilder().addAttributeType(new AttributeType(this), overwrite);
         }
 
         /**
@@ -435,8 +428,11 @@ public final class AttributeType extends SchemaElement implements Comparable<Att
     private AttributeType(Builder builder) {
         super(builder);
         Reject.ifTrue(builder.oid == null || builder.oid.isEmpty(), "An OID must be specified.");
-        Reject.ifTrue(builder.superiorTypeOID == null && builder.syntaxOID == null,
-                "Superior type and/or Syntax must not be null");
+
+        if (builder.superiorTypeOID == null && builder.syntaxOID == null
+                && !builder.getSchemaBuilder().getOptions().get(ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX)) {
+            throw new IllegalArgumentException("Superior type and/or Syntax must not be null");
+        }
 
         oid = builder.oid;
         names = unmodifiableCopyOfList(builder.names);
@@ -997,6 +993,8 @@ public final class AttributeType extends SchemaElement implements Comparable<Att
         } else if (getSuperiorType() != null && getSuperiorType().getSyntax() != null) {
             // Try to inherit the syntax from the superior type if possible
             syntax = getSuperiorType().getSyntax();
+        } else {
+            syntax = schema.getDefaultSyntax();
         }
 
         if (equalityMatchingRuleOID != null) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/BooleanSyntaxImpl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/BooleanSyntaxImpl.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
+ *      Portions Copyright 2016 ForgeRock AS.
  */
 
 package org.forgerock.opendj.ldap.schema;
@@ -70,13 +71,15 @@ final class BooleanSyntaxImpl extends AbstractSyntaxImpl {
      */
     public boolean valueIsAcceptable(final Schema schema, final ByteSequence value,
             final LocalizableMessageBuilder invalidReason) {
-        final String valueString = value.toString().toUpperCase();
+        final String valueString = value.toString();
+        final String valueUpperCase = valueString.toUpperCase();
 
-        if (!"TRUE".equals(valueString) && !"YES".equals(valueString)
-                && !"ON".equals(valueString) && !"1".equals(valueString)
-                && !"FALSE".equals(valueString) && !"NO".equals(valueString)
-                && !"OFF".equals(valueString) && !"0".equals(valueString)) {
-            invalidReason.append(WARN_ATTR_SYNTAX_ILLEGAL_BOOLEAN.get(value.toString()));
+        if (!"TRUE".equals(valueUpperCase) && !"YES".equals(valueUpperCase)
+                && !"ON".equals(valueUpperCase) && !"1".equals(valueUpperCase)
+                && !"FALSE".equals(valueUpperCase) && !"NO".equals(valueUpperCase)
+                && !"OFF".equals(valueUpperCase) && !"0".equals(valueUpperCase)) {
+            invalidReason.append(WARN_ATTR_SYNTAX_ILLEGAL_BOOLEAN.get(valueString));
+            return false;
         }
         return true;
     }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/DITContentRule.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/DITContentRule.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2011-2015 ForgeRock AS
+ *      Portions copyright 2011-2016 ForgeRock AS
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -101,6 +101,18 @@ public final class DITContentRule extends SchemaElement {
          */
         public SchemaBuilder addToSchemaOverwrite() {
             return getSchemaBuilder().addDITContentRule(new DITContentRule(this), true);
+        }
+
+        /**
+         * Adds this DIT content rule to the schema, overwriting any existing DIT content rule
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any DIT content rule with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
         }
 
         /**

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/DITStructureRule.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/DITStructureRule.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2015 ForgeRock AS
+ *      Portions copyright 2015-2016 ForgeRock AS
  */
 
 package org.forgerock.opendj.ldap.schema;
@@ -96,6 +96,18 @@ public final class DITStructureRule extends SchemaElement {
          */
         public SchemaBuilder addToSchemaOverwrite() {
             return getSchemaBuilder().addDITStructureRule(new DITStructureRule(this), true);
+        }
+
+        /**
+         * Adds this DIT structure rule to the schema, overwriting any existing DIT structure rule
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any DIT structure rule with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
         }
 
         @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/EnumSyntaxImpl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/EnumSyntaxImpl.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2014-2015 ForgeRock AS
+ *      Portions copyright 2014-2016 ForgeRock AS
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -43,7 +43,6 @@ import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.LocalizableMessageBuilder;
 import org.forgerock.opendj.ldap.ByteSequence;
 import org.forgerock.opendj.ldap.ByteString;
-import org.forgerock.util.Reject;
 
 /**
  * This class provides an enumeration-based mechanism where a new syntax and its
@@ -56,7 +55,6 @@ final class EnumSyntaxImpl extends AbstractSyntaxImpl {
     private final List<String> entries;
 
     EnumSyntaxImpl(final String oid, final List<String> entries) {
-        Reject.ifNull(oid, entries);
         this.oid = oid;
         final List<String> entryStrings = new ArrayList<>(entries.size());
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/MatchingRule.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/MatchingRule.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
- *      Portions copyright 2013-2015 ForgeRock AS.
+ *      Portions copyright 2013-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -103,6 +103,18 @@ public final class MatchingRule extends SchemaElement {
          */
         public SchemaBuilder addToSchemaOverwrite() {
             return getSchemaBuilder().addMatchingRule(new MatchingRule(this), true);
+        }
+
+        /**
+         * Adds this matching rule to the schema, overwriting any existing matching rule
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any matching rule with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
         }
 
         @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/MatchingRuleUse.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/MatchingRuleUse.java
@@ -98,6 +98,18 @@ public final class MatchingRuleUse extends SchemaElement {
         }
 
         /**
+         * Adds this matching rule use to the schema, overwriting any existing matching rule use
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any matching rule use with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
+        }
+
+        /**
          * Adds the provided list of attribute types to the list of attribute
          * type the matching rule applies to.
          *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/NameForm.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/NameForm.java
@@ -100,6 +100,18 @@ public final class NameForm extends SchemaElement {
             return getSchemaBuilder().addNameForm(new NameForm(this), true);
         }
 
+        /**
+         * Adds this name form to the schema, overwriting any existing name form
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any name form with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
+        }
+
         @Override
         public Builder description(final String description) {
             return description0(description);

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/ObjectClass.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/ObjectClass.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2015 ForgeRock AS.
+ *      Portions copyright 2015-2016 ForgeRock AS.
  */
 
 package org.forgerock.opendj.ldap.schema;
@@ -107,6 +107,18 @@ public final class ObjectClass extends SchemaElement {
          */
         public SchemaBuilder addToSchemaOverwrite() {
             return getSchemaBuilder().addObjectClass(new ObjectClass(this), true);
+        }
+
+        /**
+         * Adds this object class to the schema, overwriting any existing object class
+         * with the same numeric OID if the overwrite parameter is set to {@code true}.
+         *
+         * @param overwrite
+         *            {@code true} if any object class with the same OID should be overwritten.
+         * @return The parent schema builder.
+         */
+        SchemaBuilder addToSchema(final boolean overwrite) {
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
         }
 
         @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
@@ -1206,13 +1206,7 @@ public final class SchemaBuilder {
      * @return A builder to continue building the MatchingRule.
      */
     public MatchingRule.Builder buildMatchingRule(final MatchingRule matchingRule) {
-        return buildMatchingRule(matchingRule, true);
-    }
-
-    private MatchingRule.Builder buildMatchingRule(final MatchingRule matchingRule, final boolean initialize) {
-        if (initialize) {
-            lazyInitBuilder();
-        }
+        lazyInitBuilder();
         return new MatchingRule.Builder(matchingRule, this);
     }
 
@@ -1272,13 +1266,7 @@ public final class SchemaBuilder {
      * @return A builder to continue building the Syntax.
      */
     public Syntax.Builder buildSyntax(final Syntax syntax) {
-        return buildSyntax(syntax, true);
-    }
-
-    private Syntax.Builder buildSyntax(final Syntax syntax, final boolean initialize) {
-        if (initialize) {
-            lazyInitBuilder();
-        }
+        lazyInitBuilder();
         return new Syntax.Builder(syntax, this);
     }
 
@@ -2372,35 +2360,35 @@ public final class SchemaBuilder {
         // unlikely, may be different in the new schema.
 
         for (final Syntax syntax : schema.getSyntaxes()) {
-            buildSyntax(syntax, false).addToSchema(overwrite);
+            buildSyntax(syntax).addToSchema(overwrite);
         }
 
         for (final MatchingRule matchingRule : schema.getMatchingRules()) {
-            buildMatchingRule(matchingRule, false).addToSchema(overwrite);
+            buildMatchingRule(matchingRule).addToSchema(overwrite);
         }
 
         for (final MatchingRuleUse matchingRuleUse : schema.getMatchingRuleUses()) {
-            addMatchingRuleUse(matchingRuleUse, overwrite);
+            buildMatchingRuleUse(matchingRuleUse).addToSchema(overwrite);
         }
 
         for (final AttributeType attributeType : schema.getAttributeTypes()) {
-            addAttributeType(attributeType, overwrite);
+            buildAttributeType(attributeType).addToSchema(overwrite);
         }
 
         for (final ObjectClass objectClass : schema.getObjectClasses()) {
-            addObjectClass(objectClass, overwrite);
+            buildObjectClass(objectClass).addToSchema(overwrite);
         }
 
         for (final NameForm nameForm : schema.getNameForms()) {
-            addNameForm(nameForm, overwrite);
+            buildNameForm(nameForm).addToSchema(overwrite);
         }
 
         for (final DITContentRule contentRule : schema.getDITContentRules()) {
-            addDITContentRule(contentRule, overwrite);
+            buildDITContentRule(contentRule).addToSchema(overwrite);
         }
 
         for (final DITStructureRule structureRule : schema.getDITStuctureRules()) {
-            addDITStructureRule(structureRule, overwrite);
+            buildDITStructureRule(structureRule).addToSchema(overwrite);
         }
     }
 
@@ -2447,13 +2435,13 @@ public final class SchemaBuilder {
             nameForm2StructureRules = new HashMap<>();
             name2OIDs = new HashMap<>();
             warnings = new LinkedList<>();
-        }
 
-        if (copyOnWriteSchema != null) {
-            // Copy the schema.
-            addSchema0(copyOnWriteSchema, true);
-            options = Options.copyOf(copyOnWriteSchema.getOptions());
-            copyOnWriteSchema = null;
+            if (copyOnWriteSchema != null) {
+                // Copy the schema.
+                addSchema0(copyOnWriteSchema, true);
+                options = Options.copyOf(copyOnWriteSchema.getOptions());
+                copyOnWriteSchema = null;
+            }
         }
     }
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
@@ -384,7 +384,7 @@ public final class SchemaBuilder {
                 atBuilder.approximateMatchingRule(approxRules.get(0));
             }
 
-            if (superiorType == null && syntax == null) {
+            if (superiorType == null && syntax == null && !options.get(ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX)) {
                 throw new LocalizedIllegalArgumentException(
                     WARN_ATTR_SYNTAX_ATTRTYPE_MISSING_SYNTAX_AND_SUPERIOR.get(definition));
             }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
@@ -395,7 +395,7 @@ public final class SchemaBuilder {
             atBuilder.superiorType(superiorType)
                      .syntax(syntax);
 
-            return overwrite ? atBuilder.addToSchemaOverwrite() : atBuilder.addToSchema();
+            return atBuilder.addToSchema(overwrite);
         } catch (final DecodeException e) {
             final LocalizableMessage msg = ERR_ATTR_SYNTAX_ATTRTYPE_INVALID1.get(definition, e.getMessageObject());
             throw new LocalizedIllegalArgumentException(msg, e.getCause());
@@ -502,7 +502,7 @@ public final class SchemaBuilder {
                 }
             }
 
-            return overwrite ? contentRuleBuilder.addToSchemaOverwrite() : contentRuleBuilder.addToSchema();
+            return contentRuleBuilder.addToSchema(overwrite);
         } catch (final DecodeException e) {
             final LocalizableMessage msg = ERR_ATTR_SYNTAX_DCR_INVALID1.get(definition, e.getMessageObject());
             throw new LocalizedIllegalArgumentException(msg, e.getCause());
@@ -609,7 +609,7 @@ public final class SchemaBuilder {
             }
             ruleBuilder.nameForm(nameForm);
 
-            return overwrite ? ruleBuilder.addToSchemaOverwrite() : ruleBuilder.addToSchema();
+            return ruleBuilder.addToSchema(overwrite);
         } catch (final DecodeException e) {
             final LocalizableMessage msg = ERR_ATTR_SYNTAX_DSR_INVALID1.get(definition, e.getMessageObject());
             throw new LocalizedIllegalArgumentException(msg, e.getCause());
@@ -762,11 +762,7 @@ public final class SchemaBuilder {
             if (syntax == null) {
                 throw new LocalizedIllegalArgumentException(ERR_ATTR_SYNTAX_MR_NO_SYNTAX.get(definition));
             }
-            if (overwrite) {
-                matchingRuleBuilder.addToSchemaOverwrite();
-            } else {
-                matchingRuleBuilder.addToSchema();
-            }
+            matchingRuleBuilder.addToSchema(overwrite);
         } catch (final DecodeException e) {
             final LocalizableMessage msg =
                     ERR_ATTR_SYNTAX_MR_INVALID1.get(definition, e.getMessageObject());
@@ -875,7 +871,7 @@ public final class SchemaBuilder {
             }
             useBuilder.attributes(attributes);
 
-            return overwrite ? useBuilder.addToSchemaOverwrite() : useBuilder.addToSchema();
+            return useBuilder.addToSchema(overwrite);
         } catch (final DecodeException e) {
             final LocalizableMessage msg = ERR_ATTR_SYNTAX_MRUSE_INVALID1.get(definition, e.getMessageObject());
             throw new LocalizedIllegalArgumentException(msg, e.getCause());
@@ -1073,11 +1069,7 @@ public final class SchemaBuilder {
                 throw new LocalizedIllegalArgumentException(ERR_ATTR_SYNTAX_NAME_FORM_NO_REQUIRED_ATTR.get(definition));
             }
 
-            if (overwrite) {
-                nameFormBuilder.addToSchemaOverwrite();
-            } else {
-                nameFormBuilder.addToSchema();
-            }
+            nameFormBuilder.addToSchema(overwrite);
         } catch (final DecodeException e) {
             final LocalizableMessage msg =
                     ERR_ATTR_SYNTAX_NAME_FORM_INVALID1.get(definition, e.getMessageObject());
@@ -1408,7 +1400,7 @@ public final class SchemaBuilder {
                 }
                 ocBuilder.superiorObjectClasses(superiorClasses)
                          .type(ocType);
-                return overwrite ? ocBuilder.addToSchemaOverwrite() : ocBuilder.addToSchema();
+                return ocBuilder.addToSchema(overwrite);
             }
         } catch (final DecodeException e) {
             throw new LocalizedIllegalArgumentException(
@@ -2380,19 +2372,11 @@ public final class SchemaBuilder {
         // unlikely, may be different in the new schema.
 
         for (final Syntax syntax : schema.getSyntaxes()) {
-            if (overwrite) {
-                buildSyntax(syntax, false).addToSchemaOverwrite();
-            } else {
-                buildSyntax(syntax, false).addToSchema();
-            }
+            buildSyntax(syntax, false).addToSchema(overwrite);
         }
 
         for (final MatchingRule matchingRule : schema.getMatchingRules()) {
-            if (overwrite) {
-                buildMatchingRule(matchingRule, false).addToSchemaOverwrite();
-            } else {
-                buildMatchingRule(matchingRule, false).addToSchema();
-            }
+            buildMatchingRule(matchingRule, false).addToSchema(overwrite);
         }
 
         for (final MatchingRuleUse matchingRuleUse : schema.getMatchingRuleUses()) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaOptions.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaOptions.java
@@ -21,7 +21,7 @@
  * CDDL HEADER END
  *
  *
- *      Copyright 2014-2015 ForgeRock AS
+ *      Copyright 2014-2016 ForgeRock AS
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -59,6 +59,16 @@ public final class SchemaOptions {
      * characters are often used for naming purposes (such as collation rules).
      */
     public static final Option<Boolean> ALLOW_MALFORMED_NAMES_AND_OPTIONS = Option.withDefault(true);
+
+    /**
+     * Specifies whether the schema should allow attribute type definitions that do not declare a superior attribute
+     * type or syntax. When this compatibility option is set to {@code true} invalid attribute type definitions will
+     * use the default syntax specifed by the {@link #DEFAULT_SYNTAX_OID} option.
+     * <p>
+     * By default this compatibility option is set to {@code true} in order to remain compatible with previous
+     * versions of OpenDJ.
+     */
+    public static final Option<Boolean> ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX = Option.withDefault(true);
 
     /**
      * Specifies whether the JPEG Photo syntax should allow values which

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaUtils.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaUtils.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2011-2015 ForgeRock AS
+ *      Portions copyright 2011-2016 ForgeRock AS
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -751,9 +751,9 @@ final class SchemaUtils {
     }
 
     private static void throwIfIA5IllegalCharacter(StringBuilder buffer, ByteSequence value) throws DecodeException {
-        // Replace any consecutive spaces with a single space and watch out
-        // for non-ASCII characters.
-        for (int pos = buffer.length() - 1; pos > 0; pos--) {
+        // Check the string for any non-IA5 characters
+        final int bufferLength = buffer.length();
+        for (int pos = 0; pos < bufferLength; pos++) {
             final char c = buffer.charAt(pos);
             if ((c & 0x7F) != c) {
                 // This is not a valid character for an IA5 string. If strict

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/Syntax.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/Syntax.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2013-2014 ForgeRock AS.
+ *      Portions copyright 2013-2016 ForgeRock AS.
  */
 
 package org.forgerock.opendj.ldap.schema;
@@ -103,10 +103,7 @@ public final class Syntax extends SchemaElement {
          * @return The parent schema builder.
          */
         SchemaBuilder addToSchema(final boolean overwrite) {
-            if (overwrite) {
-                return addToSchemaOverwrite();
-            }
-            return addToSchema();
+            return overwrite ? addToSchemaOverwrite() : addToSchema();
         }
 
         @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/Syntax.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/Syntax.java
@@ -82,7 +82,7 @@ public final class Syntax extends SchemaElement {
          *             If there is an existing syntax with the same numeric OID.
          */
         public SchemaBuilder addToSchema() {
-            return getSchemaBuilder().addSyntax(new Syntax(this), false);
+            return addToSchema(false);
         }
 
         /**
@@ -91,19 +91,25 @@ public final class Syntax extends SchemaElement {
          * @return The parent schema builder.
          */
         public SchemaBuilder addToSchemaOverwrite() {
-            return getSchemaBuilder().addSyntax(new Syntax(this), true);
+            return addToSchema(true);
         }
 
-        /**
-         * Adds this syntax to the schema - overwriting any existing syntax with the same numeric OID
-         * if the overwrite parameter is set to {@code true}.
-         *
-         * @param overwrite
-         *            {@code true} if any syntax with the same OID should be overwritten.
-         * @return The parent schema builder.
-         */
         SchemaBuilder addToSchema(final boolean overwrite) {
-            return overwrite ? addToSchemaOverwrite() : addToSchema();
+            // Enumeration syntaxes will need their associated matching rule registered now as well.
+            for (final Map.Entry<String, List<String>> property : getExtraProperties().entrySet()) {
+                if ("x-enum".equalsIgnoreCase(property.getKey())) {
+                    final EnumSyntaxImpl enumSyntaxImpl = new EnumSyntaxImpl(oid, property.getValue());
+                    implementation(enumSyntaxImpl);
+                    return getSchemaBuilder().addSyntax(new Syntax(this), overwrite)
+                                             .buildMatchingRule(enumSyntaxImpl.getOrderingMatchingRule())
+                                             .description(getDescription() + " enumeration ordering matching rule")
+                                             .syntaxOID(oid)
+                                             .extraProperties(CoreSchemaImpl.OPENDS_ORIGIN)
+                                             .implementation(new EnumOrderingMatchingRule(enumSyntaxImpl))
+                                             .addToSchemaOverwrite();
+                }
+            }
+            return getSchemaBuilder().addSyntax(new Syntax(this), overwrite);
         }
 
         @Override

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/AbstractSubstringMatchingRuleImplTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/AbstractSubstringMatchingRuleImplTest.java
@@ -20,7 +20,7 @@
  *
  * CDDL HEADER END
  *
- *      Copyright 2014-2015 ForgeRock AS
+ *      Copyright 2014-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -52,6 +52,8 @@ import static org.testng.Assert.*;
  */
 @SuppressWarnings("javadoc")
 public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCase {
+
+    private int subStringLength = 3;
 
     private static class FakeSubstringMatchingRuleImpl extends AbstractSubstringMatchingRuleImpl {
 
@@ -144,8 +146,12 @@ public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCas
     }
 
     static IndexingOptions newIndexingOptions() {
+        return newIndexingOptions(3);
+    }
+
+    static IndexingOptions newIndexingOptions(int subStringLength) {
         final IndexingOptions options = mock(IndexingOptions.class);
-        when(options.substringKeySize()).thenReturn(3);
+        when(options.substringKeySize()).thenReturn(subStringLength);
         return options;
     }
 
@@ -197,6 +203,10 @@ public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCas
         return sb.toString();
     }
 
+    private String subStringIndexID(String matchingRule) {
+        return matchingRule + ":" + subStringLength;
+    }
+
     @Test(dataProvider = "validAssertions")
     public void testValidAssertions(String attrValue, String assertionValue, ConditionResult expected)
             throws Exception {
@@ -213,10 +223,10 @@ public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCas
             null, null, Collections.EMPTY_LIST, valueOfUtf8("this"));
 
         assertEquals(
-            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions())),
+            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions(subStringLength))),
             "intersect["
-                    + "exactMatch(" + SMR_CASE_EXACT_OID + ", value=='his'), "
-                    + "exactMatch(" + SMR_CASE_EXACT_OID + ", value=='thi')"
+                    + "exactMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", value=='his'), "
+                    + "exactMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", value=='thi')"
                     + "]");
     }
 
@@ -226,13 +236,13 @@ public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCas
             null, valueOfUtf8("abc"), Arrays.asList(toByteStrings("def", "ghi")), valueOfUtf8("jkl"));
 
         assertEquals(
-            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions())),
+            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions(subStringLength))),
             "intersect["
                     + "rangeMatch(" + EMR_CASE_EXACT_OID + ", 'abc' <= value < 'abd'), "
-                    + "exactMatch(" + SMR_CASE_EXACT_OID + ", value=='def'), "
-                    + "exactMatch(" + SMR_CASE_EXACT_OID + ", value=='ghi'), "
-                    + "exactMatch(" + SMR_CASE_EXACT_OID + ", value=='jkl'), "
-                    + "exactMatch(" + SMR_CASE_EXACT_OID + ", value=='abc')"
+                    + "exactMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", value=='def'), "
+                    + "exactMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", value=='ghi'), "
+                    + "exactMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", value=='jkl'), "
+                    + "exactMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", value=='abc')"
                     + "]");
     }
 
@@ -243,10 +253,10 @@ public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCas
             null, valueOfUtf8("aa"), Collections.EMPTY_LIST, null);
 
         assertEquals(
-            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions())),
+            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions(subStringLength))),
             "intersect["
-                    + "rangeMatch(" + EMR_CASE_EXACT_OID + ", 'aa' <= value < 'ab'), "
-                    + "rangeMatch(" + SMR_CASE_EXACT_OID + ", 'aa' <= value < 'ab')"
+                    + "rangeMatch(" + EMR_CASE_EXACT_OID +  ", 'aa' <= value < 'ab'), "
+                    + "rangeMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", 'aa' <= value < 'ab')"
                     + "]");
     }
 
@@ -258,12 +268,12 @@ public class AbstractSubstringMatchingRuleImplTest extends AbstractSchemaTestCas
             null, lower, Collections.EMPTY_LIST, null);
 
         assertEquals(
-            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions())),
+            assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions(subStringLength))),
             // 0x00 is the nul byte, a.k.a. string terminator
             // so everything after it is not part of the string
             "intersect["
                     + "rangeMatch(" + EMR_CASE_EXACT_OID + ", '" + lower + "' <= value < 'b\u0000'), "
-                    + "rangeMatch(" + SMR_CASE_EXACT_OID + ", '" + lower + "' <= value < 'b\u0000')"
+                    + "rangeMatch(" + subStringIndexID(SMR_CASE_EXACT_OID) + ", '" + lower + "' <= value < 'b\u0000')"
                     + "]");
     }
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/AttributeTypeTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/AttributeTypeTest.java
@@ -22,10 +22,11 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Copyright 2015 ForgeRock AS.
+ *      Copyright 2015-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.schema.SchemaConstants.*;
 
 import java.util.Iterator;
@@ -490,37 +491,39 @@ public class AttributeTypeTest extends AbstractSchemaElementTestCase {
         Assert.assertFalse(type.isSingleValue());
     }
 
-    /**
-     * Check that the simple constructor throws an NPE when mandatory parameters
-     * are not specified.
-     *
-     * @throws Exception
-     *             If the test failed unexpectedly.
-     */
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNoSupNorSyntax1() throws Exception {
-        final SchemaBuilder builder = new SchemaBuilder(Schema.getCoreSchema());
-        builder.buildAttributeType("1.2.1")
-               .names(EMPTY_NAMES)
-               .obsolete(true)
-               .usage(AttributeUsage.DSA_OPERATION)
-               .addToSchema();
-
-        builder.addAttributeType("( 1.2.2 OBSOLETE SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )", false);
-
+    @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
+    public void attributeTypeDefinitionsRequireSyntaxOrSuperiorWhenStrict1() throws Exception {
+        new SchemaBuilder(Schema.getCoreSchema())
+                .setOption(SchemaOptions.ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX, false)
+                .addAttributeType("(1.2.1)", true);
     }
 
-    /**
-     * Check that the simple constructor throws an NPE when mandatory parameters
-     * are not specified.
-     *
-     * @throws Exception
-     *             If the test failed unexpectedly.
-     */
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNoSupNorSyntax2() throws Exception {
-        final SchemaBuilder builder = new SchemaBuilder(Schema.getCoreSchema());
-        builder.addAttributeType("( 1.2.2 OBSOLETE SINGLE-VALUE )", false);
+    public void attributeTypeDefinitionsRequireSyntaxOrSuperiorWhenStrict2() throws Exception {
+        new SchemaBuilder(Schema.getCoreSchema())
+                .setOption(SchemaOptions.ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX, false)
+                .buildAttributeType("1.2.1")
+                .addToSchema();
+    }
+
+    @Test
+    public void attributeTypeDefinitionsDoNotRequireSyntaxOrSuperiorWhenTolerant1() throws Exception {
+        final Schema schema = new SchemaBuilder(Schema.getCoreSchema())
+                .addAttributeType("(1.2.1)", true).toSchema();
+        assertThat(schema.getWarnings()).isEmpty();
+        assertThat(schema.getAttributeType("1.2.1").getSuperiorType()).isNull();
+        assertThat(schema.getAttributeType("1.2.1").getSyntax()).isSameAs(schema.getDefaultSyntax());
+    }
+
+    @Test
+    public void attributeTypeDefinitionsDoNotRequireSyntaxOrSuperiorWhenTolerant2() throws Exception {
+        final Schema schema = new SchemaBuilder(Schema.getCoreSchema())
+                .buildAttributeType("1.2.1")
+                .addToSchema()
+                .toSchema();
+        assertThat(schema.getWarnings()).isEmpty();
+        assertThat(schema.getAttributeType("1.2.1").getSuperiorType()).isNull();
+        assertThat(schema.getAttributeType("1.2.1").getSyntax()).isSameAs(schema.getDefaultSyntax());
     }
 
     @Test

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/BooleanSyntaxTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/BooleanSyntaxTest.java
@@ -1,0 +1,62 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at legal-notices/CDDLv1_0.txt
+ * or http://forgerock.org/license/CDDLv1.0.html.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at legal-notices/CDDLv1_0.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information:
+ *      Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ *
+ * Copyright 2016 ForgeRock AS.
+ */
+package org.forgerock.opendj.ldap.schema;
+
+import static org.forgerock.opendj.ldap.schema.SchemaConstants.SYNTAX_BOOLEAN_OID;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** Boolean syntax tests. */
+@Test
+public class BooleanSyntaxTest extends AbstractSyntaxTestCase {
+    @Override
+    @DataProvider(name = "acceptableValues")
+    public Object[][] createAcceptableValues() {
+        return new Object[][] {
+            { "TRUE", true },
+            { "FALSE", true },
+            { "true", true },
+            { "false", true },
+            { "YES", true },
+            { "NO", true },
+            { "ON", true },
+            { "OFF", true },
+            { "1", true },
+            { "0", true },
+            { "'0'B", false },
+            { "invalidtrue", false },
+            { " true", false },
+            { "NOT", false },
+            { "'010100000111111010101000'B", false }
+        };
+    }
+
+    @Override
+    protected Syntax getRule() {
+        return Schema.getCoreSchema().getSyntax(SYNTAX_BOOLEAN_OID);
+    }
+}

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/CollationSubstringMatchingRuleTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/CollationSubstringMatchingRuleTest.java
@@ -21,7 +21,7 @@
  * CDDL HEADER END
  *
  *
- *      Copyright 2014-2015 ForgeRock AS.
+ *      Copyright 2014-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -153,15 +153,17 @@ public class CollationSubstringMatchingRuleTest extends SubstringMatchingRuleTes
         MatchingRule matchingRule = getRule();
         Assertion assertion = matchingRule.getAssertion(value);
 
-        String indexQuery = assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions(), false));
+        int subStringLength = 3;
+        String indexQuery = assertion.createIndexQuery(new FakeIndexQueryFactory(newIndexingOptions(subStringLength),
+            false));
 
         ByteString binit = matchingRule.normalizeAttributeValue(ByteString.valueOfUtf8("a"));
         ByteString bfinal = matchingRule.normalizeAttributeValue(ByteString.valueOfUtf8("c"));
         assertEquals(indexQuery,
             "intersect["
             + "rangeMatch(fr.shared, '" + binit.toHexString() + "' <= value < '00 54'), "
-            + "rangeMatch(fr.substring, '" + bfinal.toHexString() + "' <= value < '00 56'), "
-            + "rangeMatch(fr.substring, '" + binit.toHexString() + "' <= value < '00 54')]"
+            + "rangeMatch(fr.substring:" + subStringLength + ", '" + bfinal.toHexString() + "' <= value < '00 56'), "
+            + "rangeMatch(fr.substring:" + subStringLength + ", '" + binit.toHexString() + "' <= value < '00 54')]"
         );
     }
 }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaBuilderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaBuilderTestCase.java
@@ -94,11 +94,23 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
                 "1.3.6.1.4.1.1466.115.121.1.15");
     }
 
-    /** Tests that attribute types must have a syntax or a superior. */
+    /** Tests that attribute types must have a syntax or a superior when strict. */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public void attributeTypeNoSuperiorNoSyntax() {
-        new SchemaBuilder(Schema.getCoreSchema()).addAttributeType(
-                "( parenttype-oid NAME 'parenttype' )", false);
+    public void attributeTypeNoSuperiorNoSyntaxWhenStrict() {
+        new SchemaBuilder(Schema.getCoreSchema())
+                .setOption(ALLOW_ATTRIBUTE_TYPES_WITH_NO_SUP_OR_SYNTAX, false)
+                .addAttributeType("( parenttype-oid NAME 'parenttype' )", false);
+    }
+
+    /** Tests that attribute types do not have to have a syntax or a superior when leniant. */
+    @Test
+    public void attributeTypeNoSuperiorNoSyntaxWhenLeniant() {
+        final Schema schema = new SchemaBuilder(Schema.getCoreSchema())
+                .addAttributeType("( parenttype-oid NAME 'parenttype' )", false)
+                .toSchema();
+        assertThat(schema.getAttributeType("parenttype").getSyntax()).isNotNull();
+        assertThat(schema.getAttributeType("parenttype").getSyntax().getOID())
+                .isEqualTo("1.3.6.1.4.1.1466.115.121.1.40");
     }
 
     /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaBuilderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaBuilderTestCase.java
@@ -35,6 +35,9 @@ import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
 import org.forgerock.i18n.LocalizableMessageBuilder;
 import org.forgerock.i18n.LocalizedIllegalArgumentException;
 import org.forgerock.opendj.ldap.ByteString;
@@ -48,11 +51,10 @@ import org.forgerock.opendj.ldap.LinkedHashMapEntry;
 import org.forgerock.opendj.ldap.requests.SearchRequest;
 import org.forgerock.opendj.ldap.responses.Responses;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-/**
- * Test SchemaBuilder.
- */
+/** Test SchemaBuilder. */
 @SuppressWarnings("javadoc")
 public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
 
@@ -61,7 +63,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * attribute types regardless of the order in which they were added.
      */
     @Test
-    public void testAttributeTypeDependenciesChildThenParent() {
+    public void attributeTypeDependenciesChildThenParent() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema())
                         .addAttributeType("( childtype-oid NAME 'childtype' SUP parenttype )",
@@ -79,7 +81,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * attribute types regardless of the order in which they were added.
      */
     @Test
-    public void testAttributeTypeDependenciesParentThenChild() {
+    public void attributeTypeDependenciesParentThenChild() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema())
                         .addAttributeType(
@@ -92,11 +94,9 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
                 "1.3.6.1.4.1.1466.115.121.1.15");
     }
 
-    /**
-     * Tests that attribute types must have a syntax or a superior.
-     */
+    /** Tests that attribute types must have a syntax or a superior. */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public void testAttributeTypeNoSuperiorNoSyntax() {
+    public void attributeTypeNoSuperiorNoSyntax() {
         new SchemaBuilder(Schema.getCoreSchema()).addAttributeType(
                 "( parenttype-oid NAME 'parenttype' )", false);
     }
@@ -106,7 +106,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * attribute types regardless of the order.
      */
     @Test
-    public void testAttributeTypeSuperiorFailureChildThenParent() {
+    public void attributeTypeSuperiorFailureChildThenParent() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).addAttributeType(
                         "( childtype-oid NAME 'childtype' SUP parenttype )", false)
@@ -133,7 +133,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * attribute types regardless of the order.
      */
     @Test
-    public void testAttributeTypeSuperiorFailureParentThenChild() {
+    public void attributeTypeSuperiorFailureParentThenChild() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).addAttributeType(
                         "( parenttype-oid NAME 'parenttype' SUP xxx )", false).addAttributeType(
@@ -154,12 +154,9 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
         }
     }
 
-    /**
-     * Test for OPENDJ-156: Errors when parsing collective attribute
-     * definitions.
-     */
+    /** Test for OPENDJ-156: Errors when parsing collective attribute definitions. */
     @Test
-    public void testCollectiveAttribute() {
+    public void collectiveAttribute() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).addAttributeType(
                         "( 2.5.4.11.1 NAME 'c-ou' "
@@ -173,39 +170,33 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * another and take advantage of copy on write.
      */
     @Test
-    public void testCopyOnWriteNoChanges() {
+    public void copyOnWriteNoChanges() {
         final Schema baseSchema = Schema.getCoreSchema();
         final Schema schema = new SchemaBuilder(baseSchema).toSchema();
 
         assertThat(schema).isSameAs(baseSchema);
     }
 
-    /**
-     * Tests that it is possible to create a schema which is based on another.
-     */
+    /** Tests that it is possible to create a schema which is based on another. */
     @Test
-    public void testCopyOnWriteWithChanges() {
-
+    public void copyOnWriteWithChanges() {
         final Schema baseSchema = Schema.getCoreSchema();
         final Schema schema =
                 new SchemaBuilder(baseSchema).addAttributeType(
                         "( testtype-oid NAME 'testtype' SUP name )", false).toSchema();
         assertThat(schema).isNotSameAs(baseSchema);
-        assertThat(schema.getObjectClasses().containsAll(baseSchema.getObjectClasses()));
-        assertThat(schema.getObjectClasses().size())
-                .isEqualTo(baseSchema.getObjectClasses().size());
+        assertThat(new ArrayList<>(schema.getObjectClasses())).isEqualTo(
+                new ArrayList<>(baseSchema.getObjectClasses()));
         assertThat(schema.getAttributeTypes().containsAll(baseSchema.getAttributeTypes()));
         assertThat(schema.getAttributeType("testtype")).isNotNull();
-        assertThat(schema.getSchemaName()).isEqualTo(baseSchema.getSchemaName());
+        assertThat(schema.getSchemaName()).startsWith(baseSchema.getSchemaName());
         assertThat(schema.getOption(ALLOW_MALFORMED_NAMES_AND_OPTIONS))
                 .isEqualTo(baseSchema.getOption(ALLOW_MALFORMED_NAMES_AND_OPTIONS));
     }
 
-    /**
-     * Tests that it is possible to create an empty schema.
-     */
+    /** Tests that it is possible to create an empty schema. */
     @Test
-    public void testCreateEmptySchema() {
+    public void createEmptySchema() {
         final Schema schema = new SchemaBuilder().toSchema();
         assertThat(schema.getAttributeTypes()).isEmpty();
         assertThat(schema.getObjectClasses()).isEmpty();
@@ -217,12 +208,9 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
         // Could go on...
     }
 
-    /**
-     * Tests that multiple consecutive invocations of toSchema return the exact
-     * same schema.
-     */
+    /** Tests that multiple consecutive invocations of toSchema return the exact same schema. */
     @Test
-    public void testMultipleToSchema1() {
+    public void multipleToSchema1() {
         final Schema baseSchema = Schema.getCoreSchema();
         final SchemaBuilder builder = new SchemaBuilder(baseSchema);
         final Schema schema1 = builder.toSchema();
@@ -231,12 +219,9 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
         assertThat(schema1).isSameAs(schema2);
     }
 
-    /**
-     * Tests that multiple consecutive invocations of toSchema return the exact
-     * same schema.
-     */
+    /** Tests that multiple consecutive invocations of toSchema return the exact same schema. */
     @Test
-    public void testMultipleToSchema2() {
+    public void multipleToSchema2() {
         final SchemaBuilder builder =
                 new SchemaBuilder().addAttributeType(
                         "( testtype-oid NAME 'testtype' SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )",
@@ -253,7 +238,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * object classes regardless of the order in which they were added.
      */
     @Test
-    public void testObjectClassDependenciesChildThenParent() {
+    public void objectClassDependenciesChildThenParent() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).addObjectClass(
                         "( childtype-oid NAME 'childtype' SUP parenttype STRUCTURAL MUST sn )",
@@ -273,7 +258,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * object classes regardless of the order in which they were added.
      */
     @Test
-    public void testObjectClassDependenciesParentThenChild() {
+    public void objectClassDependenciesParentThenChild() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema())
                         .addObjectClass(
@@ -295,7 +280,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * object classes regardless of the order.
      */
     @Test
-    public void testObjectClassSuperiorFailureChildThenParent() {
+    public void objectClassSuperiorFailureChildThenParent() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).addObjectClass(
                         "( childtype-oid NAME 'childtype' SUP parenttype STRUCTURAL MUST sn )",
@@ -323,7 +308,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * object classes regardless of the order.
      */
     @Test
-    public void testObjectClassSuperiorFailureParentThenChild() {
+    public void objectClassSuperiorFailureParentThenChild() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema())
                         .addObjectClass(
@@ -348,12 +333,9 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
         }
     }
 
-    /**
-     * Tests that a schema builder can be re-used after toSchema has been
-     * called.
-     */
+    /** Tests that a schema builder can be re-used after toSchema has been called. */
     @Test
-    public void testReuseSchemaBuilder() {
+    public void reuseSchemaBuilder() {
         final SchemaBuilder builder = new SchemaBuilder();
         final Schema schema1 =
                 builder.addAttributeType(
@@ -378,7 +360,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = NullPointerException.class)
-    public final void testSchemaBuilderDoesntAllowNullEntry() throws Exception {
+    public final void schemaBuilderDoesntAllowNullEntry() throws Exception {
         new SchemaBuilder((Entry) null);
     }
 
@@ -388,7 +370,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryWithCoreSchema() throws Exception {
+    public final void schemaBuilderWithEntryWithCoreSchema() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -440,7 +422,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderWithEntryWithoutCoreSchema() throws Exception {
+    public final void schemaBuilderWithEntryWithoutCoreSchema() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -476,7 +458,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAttributeWithoutSpace() throws Exception {
+    public final void schemaBuilderAttributeWithoutSpace() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -514,7 +496,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAttributeExtensionWithoutSpace() throws Exception {
+    public final void schemaBuilderAttributeExtensionWithoutSpace() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -552,7 +534,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddLdapSyntax() throws Exception {
+    public final void schemaBuilderWithEntryAddLdapSyntax() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -593,7 +575,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMalformedLdapSyntax() throws Exception {
+    public final void schemaBuilderWithEntryAddMalformedLdapSyntax() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -632,7 +614,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMatchingRuleUse() throws Exception {
+    public final void schemaBuilderWithEntryAddMatchingRuleUse() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -674,7 +656,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMalformedMatchingRuleUse() throws Exception {
+    public final void schemaBuilderWithEntryAddMalformedMatchingRuleUse() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -713,7 +695,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMatchingRule() throws Exception {
+    public final void schemaBuilderWithEntryAddMatchingRule() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -756,7 +738,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMalformedMatchingRule() throws Exception {
+    public final void schemaBuilderWithEntryAddMalformedMatchingRule() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -796,7 +778,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddDITContentRule() throws Exception {
+    public final void schemaBuilderWithEntryAddDITContentRule() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -839,7 +821,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMalformedDITContentRule() throws Exception {
+    public final void schemaBuilderWithEntryAddMalformedDITContentRule() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -879,7 +861,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddObjectClass() throws Exception {
+    public final void schemaBuilderWithEntryAddObjectClass() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -920,7 +902,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderWithEntryAddMalformedObjectClass() throws Exception {
+    public final void schemaBuilderWithEntryAddMalformedObjectClass() throws Exception {
         // @formatter:off
         final String[] strEntry = {
             "dn: cn=schema",
@@ -961,7 +943,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAddAttributeWithEntryContainingDescriptionWithCoreSchema()
+    public final void schemaBuilderAddAttributeWithEntryContainingDescriptionWithCoreSchema()
             throws Exception {
         // @formatter:off
         final String[] strEntry = {
@@ -1016,9 +998,8 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAddAttributeContainingDescriptionWithCoreSchema()
+    public final void schemaBuilderAddAttributeContainingDescriptionWithCoreSchema()
             throws Exception {
-
         final SchemaBuilder scBuild = new SchemaBuilder();
         // Adding the new schema containing the customclass
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
@@ -1051,8 +1032,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public final void testSchemaBuilderAddAttributeDoesntAllowWrongUsage() throws Exception {
-
+    public final void schemaBuilderAddAttributeDoesntAllowWrongUsage() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         // Adding the new schema containing the customclass
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
@@ -1069,7 +1049,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = NullPointerException.class)
-    public final void testSchemaBuilderAddAttributeTypeDoesntAllowNull() throws Exception {
+    public final void schemaBuilderAddAttributeTypeDoesntAllowNull() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         // Adding the new schema containing the customclass
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
@@ -1083,14 +1063,12 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public final void testSchemaBuilderAddAttributeTypeDoesntAllowEmptyString() throws Exception {
-
+    public final void schemaBuilderAddAttributeTypeDoesntAllowEmptyString() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         // Adding the new schema containing the customclass
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
                 + "' SUP top AUXILIARY MAY myCustomAttribute )", false);
         scBuild.addAttributeType(" ", false);
-
     }
 
     /**
@@ -1100,9 +1078,8 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public final void testSchemaBuilderAddAttributeDoesntAllowLeftParenthesisMising()
+    public final void schemaBuilderAddAttributeDoesntAllowLeftParenthesisMising()
             throws Exception {
-
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getDefaultSchema());
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
                 + "' SUP top AUXILIARY MAY myCustomAttribute )", false);
@@ -1120,9 +1097,8 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public final void testSchemaBuilderAddAttributeDoesntAllowRightParenthesisMising()
+    public final void schemaBuilderAddAttributeDoesntAllowRightParenthesisMising()
             throws Exception {
-
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getDefaultSchema());
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
                 + "' SUP top AUXILIARY MAY myCustomAttribute )", false);
@@ -1140,8 +1116,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderCompareAddAttributeTypesSucceed() throws Exception {
-
+    public final void schemaBuilderCompareAddAttributeTypesSucceed() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getDefaultSchema());
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
                 + "' SUP top AUXILIARY MAY myCustomAttribute )", false);
@@ -1189,9 +1164,8 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public final void testSchemaBuilderAddObjectClassDoesntAllowMalformedObjectClass()
+    public final void schemaBuilderAddObjectClassDoesntAllowMalformedObjectClass()
             throws Exception {
-
         final SchemaBuilder scBuild = new SchemaBuilder();
         // Left parenthesis is missing underneath
         scBuild.addObjectClass(" temporary-fake-oc-id NAME 'myCustomObjClass"
@@ -1210,9 +1184,8 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = LocalizedIllegalArgumentException.class)
-    public final void testSchemaBuilderAddObjectClassDoesntAllowMalformedObjectClassIllegalToken()
+    public final void schemaBuilderAddObjectClassDoesntAllowMalformedObjectClassIllegalToken()
             throws Exception {
-
         final SchemaBuilder scBuild = new SchemaBuilder();
         // Wrong object class definition (AUXI)
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
@@ -1224,11 +1197,9 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
                 false);
     }
 
-    /**
-     * Rewrite an existing object class.
-     */
+    /** Rewrite an existing object class. */
     @Test
-    public final void testSchemaBuilderAddObjectClass() throws Exception {
+    public final void schemaBuilderAddObjectClass() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(getDefaultSchema());
         scBuild.buildObjectClass("2.5.6.14")
                 .names("device")
@@ -1253,9 +1224,8 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = ConflictingSchemaElementException.class)
-    public final void testSchemaBuilderDoesntAllowConflictingAttributesOverwriteFalse()
+    public final void schemaBuilderDoesntAllowConflictingAttributesOverwriteFalse()
             throws Exception {
-
         final SchemaBuilder scBuild = new SchemaBuilder();
 
         scBuild.addAttributeType(
@@ -1272,7 +1242,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public final void testSchemaBuilderWithAttributeUsageDifferentFromSuperior() {
+    public final void schemaBuilderWithAttributeUsageDifferentFromSuperior() {
         final SchemaBuilder scBuild = new SchemaBuilder();
 
         // directoryOperation can't inherit from userApplications
@@ -1294,7 +1264,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAllowsConflictingAttributesOverwriteTrue() throws Exception {
+    public final void schemaBuilderAllowsConflictingAttributesOverwriteTrue() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
 
         //@formatter:off
@@ -1333,7 +1303,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = ConflictingSchemaElementException.class)
-    public final void testSchemaBuilderDoesntAllowConflictingDITOverwriteFalse() throws Exception {
+    public final void schemaBuilderDoesntAllowConflictingDITOverwriteFalse() throws Exception {
         //@formatter:off
         new SchemaBuilder(Schema.getDefaultSchema())
                 .addObjectClass(
@@ -1373,7 +1343,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAllowsConflictingDITStructureRuleOverwriteTrue()
+    public final void schemaBuilderAllowsConflictingDITStructureRuleOverwriteTrue()
             throws Exception {
         // @formatter:off
         final Schema schema =
@@ -1421,7 +1391,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAddDITContentRuleBuilder() throws Exception {
+    public final void schemaBuilderAddDITContentRuleBuilder() throws Exception {
         // @formatter:off
         final Schema schema =
             new SchemaBuilder(Schema.getCoreSchema())
@@ -1450,7 +1420,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = ConflictingSchemaElementException.class)
-    public final void testSchemaBuilderDoesntAllowConflictingDITContentRuleOverwriteFalse()
+    public final void schemaBuilderDoesntAllowConflictingDITContentRuleOverwriteFalse()
             throws Exception {
         // @formatter:off
         new SchemaBuilder(Schema.getDefaultSchema())
@@ -1481,7 +1451,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAllowsConflictingDITContentRuleOverwriteTrue()
+    public final void schemaBuilderAllowsConflictingDITContentRuleOverwriteTrue()
             throws Exception {
         // @formatter:off
         final Schema schema = new SchemaBuilder(Schema.getDefaultSchema())
@@ -1518,7 +1488,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = ConflictingSchemaElementException.class)
-    public final void testSchemaBuilderDoesntAllowConflictingMatchingRuleOverwriteFalse()
+    public final void schemaBuilderDoesntAllowConflictingMatchingRuleOverwriteFalse()
             throws Exception {
         // @formatter:off
         new SchemaBuilder(Schema.getDefaultSchema())
@@ -1538,7 +1508,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAllowsConflictingMatchingRuleOverwriteTrue()
+    public final void schemaBuilderAllowsConflictingMatchingRuleOverwriteTrue()
             throws Exception {
         // @formatter:off
         final Schema schema =
@@ -1565,7 +1535,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = ConflictingSchemaElementException.class)
-    public final void testSchemaBuilderDoesntAllowConflictingMatchingRuleUseOverwriteFalse()
+    public final void schemaBuilderDoesntAllowConflictingMatchingRuleUseOverwriteFalse()
             throws Exception {
         // @formatter:off
         new SchemaBuilder(Schema.getDefaultSchema())
@@ -1584,7 +1554,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAllowsConflictingMatchingRuleUseOverwriteTrue()
+    public final void schemaBuilderAllowsConflictingMatchingRuleUseOverwriteTrue()
             throws Exception {
         // @formatter:off
         final Schema schema =
@@ -1608,7 +1578,6 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
                             + " X-ORIGIN 'RFC 4512' )");
         }
         assertThat(schema.getWarnings()).isEmpty();
-
     }
 
     /**
@@ -1618,7 +1587,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = ConflictingSchemaElementException.class)
-    public final void testSchemaBuilderDoesntAllowConflictingNameFormOverwriteFalse()
+    public final void schemaBuilderDoesntAllowConflictingNameFormOverwriteFalse()
             throws Exception {
         // @formatter:off
         new SchemaBuilder(Schema.getDefaultSchema())
@@ -1642,7 +1611,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAllowsConflictingNameFormOverwriteTrue() throws Exception {
+    public final void schemaBuilderAllowsConflictingNameFormOverwriteTrue() throws Exception {
         // @formatter:off
         final Schema schema =
             new SchemaBuilder(Schema.getDefaultSchema())
@@ -1680,8 +1649,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveAttributeType() throws Exception {
-
+    public final void schemaBuilderRemoveAttributeType() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getDefaultSchema());
         scBuild.addObjectClass("( temporary-fake-oc-id NAME 'myCustomObjClass"
                 + "' SUP top AUXILIARY MAY myCustomAttribute )", false);
@@ -1704,7 +1672,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantAttributeType() throws Exception {
+    public final void schemaBuilderRemoveInexistantAttributeType() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeAttributeType("wrongName");
         assertThat(isRemoved).isFalse();
@@ -1716,7 +1684,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantSyntax() throws Exception {
+    public final void schemaBuilderRemoveInexistantSyntax() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeSyntax("1.3.6.1.4.1.14aa");
         assertThat(isRemoved).isFalse();
@@ -1728,8 +1696,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveSyntax() throws Exception {
-
+    public final void schemaBuilderRemoveSyntax() throws Exception {
         assertThat(Schema.getCoreSchema().getSyntax("1.3.6.1.4.1.1466.115.121.1.15")).isNotNull();
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getDefaultSchema());
 
@@ -1745,7 +1712,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveDitContentRule() throws Exception {
+    public final void schemaBuilderRemoveDitContentRule() throws Exception {
         // @formatter:off
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         scBuild.addObjectClass("( 2.16.840.1.113730.3.2.2 NAME 'myCustomObjClass"
@@ -1771,7 +1738,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantDitContentRule() throws Exception {
+    public final void schemaBuilderRemoveInexistantDitContentRule() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeDITContentRule("badDITContentRule");
         assertThat(isRemoved).isFalse();
@@ -1783,8 +1750,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveDitStructureRule() throws Exception {
-
+    public final void schemaBuilderRemoveDitStructureRule() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         scBuild.addObjectClass(
                 "( testditstructureruleconstraintssupoc-oid "
@@ -1820,7 +1786,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantDitStructureRule() throws Exception {
+    public final void schemaBuilderRemoveInexistantDitStructureRule() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeDITStructureRule(999014);
         assertThat(isRemoved).isFalse();
@@ -1832,8 +1798,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveMatchingRule() throws Exception {
-
+    public final void schemaBuilderRemoveMatchingRule() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         scBuild.addMatchingRule(
                 // Matching rules from RFC 2252
@@ -1853,7 +1818,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantMatchingRule() throws Exception {
+    public final void schemaBuilderRemoveInexistantMatchingRule() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeMatchingRule("bitStringMatchZ");
         assertThat(isRemoved).isFalse();
@@ -1865,8 +1830,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveMatchingRuleUSe() throws Exception {
-
+    public final void schemaBuilderRemoveMatchingRuleUSe() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         scBuild.addMatchingRuleUse(
                 "( 2.5.13.16 NAME 'bitStringMatch' APPLIES ( givenName $ surname ) )", false);
@@ -1884,7 +1848,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantMatchingRuleUse() throws Exception {
+    public final void schemaBuilderRemoveInexistantMatchingRuleUse() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeMatchingRuleUse("bitStringMatchZ");
         assertThat(isRemoved).isFalse();
@@ -1896,8 +1860,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveNameForm() throws Exception {
-
+    public final void schemaBuilderRemoveNameForm() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         scBuild.addNameForm("( testviolatessinglevaluednameform-oid "
                 + "NAME 'testViolatesSingleValuedNameForm' "
@@ -1916,7 +1879,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantNameForm() throws Exception {
+    public final void schemaBuilderRemoveInexistantNameForm() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeNameForm("bitStringMatchZ");
         assertThat(isRemoved).isFalse();
@@ -1928,8 +1891,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = UnknownSchemaElementException.class)
-    public final void testSchemaBuilderRemoveObjectClass() throws Exception {
-
+    public final void schemaBuilderRemoveObjectClass() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder();
         scBuild.addObjectClass("( 2.5.6.6 NAME 'person' SUP top STRUCTURAL MUST ( sn $ cn )"
                 + " MAY ( userPassword $ telephoneNumber $ seeAlso $ description )"
@@ -1947,7 +1909,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderRemoveInexistantObjectClass() throws Exception {
+    public final void schemaBuilderRemoveInexistantObjectClass() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         boolean isRemoved = scBuild.removeObjectClass("bitStringMatchZ");
         assertThat(isRemoved).isFalse();
@@ -1959,8 +1921,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = NullPointerException.class)
-    public final void testSchemaBuilderAddSchemaForEntryDoesntAllowNull() throws Exception {
-
+    public final void schemaBuilderAddSchemaForEntryDoesntAllowNull() throws Exception {
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
         scBuild.addSchemaForEntry(null, null, false);
     }
@@ -1974,7 +1935,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test(expectedExceptions = EntryNotFoundException.class)
-    public final void testSchemaBuilderAddSchemaForEntryDoesntContainSubschemaMockConnection()
+    public final void schemaBuilderAddSchemaForEntryDoesntContainSubschemaMockConnection()
             throws Exception {
         Connection connection = mock(Connection.class);
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
@@ -1997,7 +1958,6 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
 
         scBuild.addSchemaForEntry(connection,
                 DN.valueOf("uid=scarter,ou=People,dc=example,dc=com"), false);
-
     }
 
     /**
@@ -2006,7 +1966,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAddSchemaForEntryMockConnection() throws Exception {
+    public final void schemaBuilderAddSchemaForEntryMockConnection() throws Exception {
         Connection connection = mock(Connection.class);
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
 
@@ -2056,7 +2016,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
      * @throws Exception
      */
     @Test
-    public final void testSchemaBuilderAddSchemaForEntryAsyncMockConnection() throws Exception {
+    public final void schemaBuilderAddSchemaForEntryAsyncMockConnection() throws Exception {
         Connection connection = mock(Connection.class);
         final SchemaBuilder scBuild = new SchemaBuilder(Schema.getCoreSchema());
 
@@ -2099,7 +2059,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public void testDefaultSyntax() {
+    public void defaultSyntax() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).toSchema().asNonStrictSchema();
         assertThat(schema.getDefaultSyntax()).isEqualTo(CoreSchema.getOctetStringSyntax());
@@ -2108,7 +2068,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public void testOverrideDefaultSyntax() {
+    public void overrideDefaultSyntax() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema())
                     .setOption(DEFAULT_SYNTAX_OID, getDirectoryStringSyntax().getOID())
@@ -2118,7 +2078,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public void testDefaultMatchingRule() {
+    public void defaultMatchingRule() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema()).toSchema().asNonStrictSchema();
         assertThat(schema.getDefaultMatchingRule()).isEqualTo(
@@ -2128,7 +2088,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public void testOverrideMatchingRule() {
+    public void overrideMatchingRule() {
         final Schema schema =
                 new SchemaBuilder(Schema.getCoreSchema())
                     .setOption(DEFAULT_MATCHING_RULE_OID, getCaseIgnoreMatchingRule().getOID())
@@ -2140,7 +2100,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public void testDefaultSyntaxDefinedInSchema() {
+    public void defaultSyntaxDefinedInSchema() {
         // The next line was triggering a NPE with OPENDJ-1252.
         final Schema schema =
                 new SchemaBuilder().addSyntax("( 9.9.9 DESC 'Test Syntax' )", false).addSyntax(
@@ -2152,7 +2112,7 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
-    public void testDefaultMatchingRuleDefinedInSchema() throws DecodeException {
+    public void defaultMatchingRuleDefinedInSchema() throws DecodeException {
         final Schema schema =
                 new SchemaBuilder().addSyntax(CoreSchema.getOctetStringSyntax().toString(), false)
                         .addMatchingRule(
@@ -2165,6 +2125,30 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
         assertThat(
                 schema.getMatchingRule("9.9.9").normalizeAttributeValue(ByteString.valueOfUtf8("test")))
                 .isEqualTo(ByteString.valueOfUtf8("test"));
+    }
+
+    @Test
+    public void enumSyntaxAddThenRemove() {
+        final Schema coreSchema = Schema.getCoreSchema();
+        final Schema schemaWithEnum = new SchemaBuilder(coreSchema)
+            .addSyntax("( 3.3.3  DESC 'Day Of The Week'  "
+                    + "X-ENUM  ( 'monday' 'tuesday'   'wednesday'  'thursday'  'friday'  'saturday' 'sunday') )",
+                    false)
+            .toSchema();
+
+        assertThat(schemaWithEnum.getWarnings()).isEmpty();
+        assertThat(schemaWithEnum.getMatchingRules())
+            .as("Expected an enum ordering matching rule to be added for the enum syntax")
+            .hasSize(coreSchema.getMatchingRules().size() + 1);
+
+        final SchemaBuilder builder = new SchemaBuilder(schemaWithEnum);
+        assertThat(builder.removeSyntax("3.3.3")).isTrue();
+        final Schema schemaNoEnum = builder.toSchema();
+
+        assertThat(schemaNoEnum.getWarnings()).isEmpty();
+        assertThat(schemaNoEnum.getMatchingRules())
+            .as("Expected the enum ordering matching rule to be removed at the same time as the enum syntax")
+            .hasSize(coreSchema.getMatchingRules().size());
     }
 
     @Test
@@ -2185,5 +2169,170 @@ public class SchemaBuilderTestCase extends AbstractSchemaTestCase {
         assertThat(isValid)
                 .as("Value should have been valid, but it is not: " + invalidReason.toString())
                 .isTrue();
+    }
+
+    @DataProvider
+    private Object[][] schemasWithEnumerationSyntaxes() {
+        final Schema coreSchema = Schema.getCoreSchema();
+
+        final Schema usingAddEnumerationSyntax = new SchemaBuilder("usingAddEnumerationSyntax")
+                .addSchema(coreSchema, true)
+                .addEnumerationSyntax("3.3.3", "Primary colors", true, "red", "green", "blue")
+                .toSchema();
+
+        final Schema usingAddSyntaxString = new SchemaBuilder("usingAddSyntaxString")
+                .addSchema(coreSchema, true)
+                .addSyntax("( 3.3.3  DESC 'Primary colors' X-ENUM ( 'red' 'green' 'blue' ))", true)
+                .toSchema();
+
+        final Schema usingBuildSyntaxCopy = new SchemaBuilder("usingBuildSyntaxCopy")
+                .addSchema(coreSchema, true)
+                .buildSyntax(usingAddEnumerationSyntax.getSyntax("3.3.3")).addToSchema()
+                .toSchema();
+
+        final Schema usingBuildSyntaxIncremental = new SchemaBuilder("usingBuildSyntaxIncremental")
+                .addSchema(coreSchema, true)
+                .buildSyntax("3.3.3")
+                .description("Primary colors")
+                .extraProperties("X-ENUM", "red", "green", "blue")
+                .addToSchema()
+                .toSchema();
+
+        final Schema usingCopyOfSchema = new SchemaBuilder("usingCopyOfSchema")
+                .addSchema(usingAddEnumerationSyntax, true)
+                .toSchema();
+
+        return new Object[][] {
+            { usingAddEnumerationSyntax },
+            { usingAddSyntaxString },
+            { usingBuildSyntaxCopy },
+            { usingBuildSyntaxIncremental },
+            { usingCopyOfSchema }
+        };
+    }
+
+    @Test(dataProvider = "schemasWithEnumerationSyntaxes")
+    public void enumerationSyntaxesCanBeCreatedUsingDifferentApproaches(Schema schema) {
+        assertThat(schema.getWarnings()).isEmpty();
+        assertThat(schema.getMatchingRules())
+                .as("Expected an enum ordering matching rule to be added for the enum syntax")
+                .hasSize(Schema.getCoreSchema().getMatchingRules().size() + 1);
+
+        LocalizableMessageBuilder msgBuilder = new LocalizableMessageBuilder();
+        Syntax primaryColors = schema.getSyntax("3.3.3");
+        assertThat(primaryColors.valueIsAcceptable(ByteString.valueOfUtf8("red"), msgBuilder)).isTrue();
+        assertThat(primaryColors.valueIsAcceptable(ByteString.valueOfUtf8("yellow"), msgBuilder)).isFalse();
+
+        MatchingRule matchingRule = schema.getMatchingRule(OMR_OID_GENERIC_ENUM + "." + "3.3.3");
+        assertThat(matchingRule).isNotNull();
+        assertThat(matchingRule).isSameAs(primaryColors.getOrderingMatchingRule());
+    }
+
+    @DataProvider
+    private Object[][] schemasWithSubstitutionSyntaxes() {
+        final Schema coreSchema = Schema.getCoreSchema();
+
+        final Schema usingAddSubstitutionSyntax = new SchemaBuilder("usingAddSubstitutionSyntax")
+                .addSchema(coreSchema, true)
+                .addSubstitutionSyntax("3.3.3", "Long Integer", "1.3.6.1.4.1.1466.115.121.1.27", true)
+                .toSchema();
+
+        final Schema usingAddSyntaxString = new SchemaBuilder("usingAddSyntaxString")
+                .addSchema(coreSchema, true)
+                .addSyntax("( 3.3.3  DESC 'Long Integer' X-SUBST '1.3.6.1.4.1.1466.115.121.1.27' )", true)
+                .toSchema();
+
+        final Schema usingBuildSyntaxCopy = new SchemaBuilder("usingBuildSyntaxCopy")
+                .addSchema(coreSchema, true)
+                .buildSyntax(usingAddSubstitutionSyntax.getSyntax("3.3.3")).addToSchema()
+                .toSchema();
+
+        final Schema usingBuildSyntaxIncremental = new SchemaBuilder("usingBuildSyntaxIncremental")
+                .addSchema(coreSchema, true)
+                .buildSyntax("3.3.3")
+                .description("Long Integer")
+                .extraProperties("X-SUBST", "1.3.6.1.4.1.1466.115.121.1.27")
+                .addToSchema()
+                .toSchema();
+
+        final Schema usingCopyOfSchema = new SchemaBuilder("usingCopyOfSchema")
+                .addSchema(usingAddSubstitutionSyntax, true)
+                .toSchema();
+
+        return new Object[][] {
+            { usingAddSubstitutionSyntax },
+            { usingAddSyntaxString },
+            { usingBuildSyntaxCopy },
+            { usingBuildSyntaxIncremental },
+            { usingCopyOfSchema }
+        };
+    }
+
+    @Test(dataProvider = "schemasWithSubstitutionSyntaxes")
+    public void substitutionSyntaxesCanBeCreatedUsingDifferentApproaches(Schema schema) {
+        assertThat(schema.getWarnings()).isEmpty();
+
+        LocalizableMessageBuilder msgBuilder = new LocalizableMessageBuilder();
+        Syntax longInteger = schema.getSyntax("3.3.3");
+        assertThat(longInteger.valueIsAcceptable(ByteString.valueOfUtf8("12345"), msgBuilder)).isTrue();
+        assertThat(longInteger.valueIsAcceptable(ByteString.valueOfUtf8("NaN"), msgBuilder)).isFalse();
+
+        MatchingRule matchingRule = schema.getMatchingRule("integerOrderingMatch");
+        assertThat(matchingRule).isNotNull();
+        assertThat(matchingRule).isSameAs(longInteger.getOrderingMatchingRule());
+    }
+
+    @DataProvider
+    private Object[][] schemasWithPatternSyntaxes() {
+        final Schema coreSchema = Schema.getCoreSchema();
+
+        final Schema usingAddPatternSyntax = new SchemaBuilder("usingAddSubstitutionSyntax")
+                .addSchema(coreSchema, true)
+                .addPatternSyntax("3.3.3", "Host and Port", Pattern.compile("[^:]+:\\d+"), true)
+                .toSchema();
+
+        final Schema usingAddSyntaxString = new SchemaBuilder("usingAddSyntaxString")
+                .addSchema(coreSchema, true)
+                .addSyntax("( 3.3.3  DESC 'Host and Port' X-PATTERN '[^:]+:\\d+' )", true)
+                .toSchema();
+
+        final Schema usingBuildSyntaxCopy = new SchemaBuilder("usingBuildSyntaxCopy")
+                .addSchema(coreSchema, true)
+                .buildSyntax(usingAddPatternSyntax.getSyntax("3.3.3")).addToSchema()
+                .toSchema();
+
+        final Schema usingBuildSyntaxIncremental = new SchemaBuilder("usingBuildSyntaxIncremental")
+                .addSchema(coreSchema, true)
+                .buildSyntax("3.3.3")
+                .description("Host and Port")
+                .extraProperties("X-PATTERN", "[^:]+:\\d+")
+                .addToSchema()
+                .toSchema();
+
+        final Schema usingCopyOfSchema = new SchemaBuilder("usingCopyOfSchema")
+                .addSchema(usingAddPatternSyntax, true)
+                .toSchema();
+
+        return new Object[][] {
+            { usingAddPatternSyntax },
+            { usingAddSyntaxString },
+            { usingBuildSyntaxCopy },
+            { usingBuildSyntaxIncremental },
+            { usingCopyOfSchema }
+        };
+    }
+
+    @Test(dataProvider = "schemasWithPatternSyntaxes")
+    public void patternSyntaxesCanBeCreatedUsingDifferentApproaches(Schema schema) {
+        assertThat(schema.getWarnings()).isEmpty();
+
+        LocalizableMessageBuilder msgBuilder = new LocalizableMessageBuilder();
+        Syntax longInteger = schema.getSyntax("3.3.3");
+        assertThat(longInteger.valueIsAcceptable(ByteString.valueOfUtf8("localhost:389"), msgBuilder)).isTrue();
+        assertThat(longInteger.valueIsAcceptable(ByteString.valueOfUtf8("bad"), msgBuilder)).isFalse();
+
+        MatchingRule matchingRule = schema.getMatchingRule("caseIgnoreOrderingMatch");
+        assertThat(matchingRule).isNotNull();
+        assertThat(matchingRule).isSameAs(longInteger.getOrderingMatchingRule());
     }
 }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaUtilsTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaUtilsTest.java
@@ -22,7 +22,7 @@
  *
  *
  *      Copyright 2009 Sun Microsystems, Inc.
- *      Portions copyright 2011-2015 ForgeRock AS
+ *      Portions copyright 2011-2016 ForgeRock AS
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -94,15 +94,19 @@ public class SchemaUtilsTest extends AbstractSchemaTestCase {
     @DataProvider
     public Object[][] nonAsciiStringProvider() throws Exception {
         final String nonAsciiChars = "ëéèêœ";
+        final String singleNonAsciiChar = "ë";
         final String nonAsciiCharsReplacement = new String(
                 new byte[] { b(0x65), b(0xcc), b(0x88), b(0x65), b(0xcc),
                     b(0x81), b(0x65), b(0xcc), b(0x80), b(0x65), b(0xcc),
                     b(0x82), b(0xc5), b(0x93), }, "UTF8");
+        final String singleNonAsciiCharReplacement = new String(
+            new byte[] { b(0x65), b(0xcc), b(0x88) }, "UTF8");
         return new Object[][] {
             { nonAsciiChars, false, false, nonAsciiCharsReplacement },
             { nonAsciiChars, false, true,  nonAsciiCharsReplacement },
             { nonAsciiChars, true,  false, nonAsciiCharsReplacement },
             { nonAsciiChars, true,  true,  nonAsciiCharsReplacement },
+            { singleNonAsciiChar, true,  true,  singleNonAsciiCharReplacement }
         };
     }
 

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2015 ForgeRock AS.
+  !      Copyright 2015-2016 ForgeRock AS.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -21,7 +21,7 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2013-2015 ForgeRock AS
+  !      Copyright 2013-2016 ForgeRock AS
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -21,7 +21,7 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2011-2015 ForgeRock AS.
+  !      Copyright 2011-2016 ForgeRock AS.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -12,7 +12,7 @@
   ! Header, with the fields enclosed by brackets [] replaced by your own identifying
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
-  ! Copyright 2012-2015 ForgeRock AS.
+  ! Copyright 2012-2016 ForgeRock AS.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -21,7 +21,7 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2011-2015 ForgeRock AS.
+  !      Copyright 2011-2016 ForgeRock AS.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-sdk-bom</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.forgerock.opendj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-sdk-bom</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.forgerock</groupId>
-        <artifactId>forgerock-parent</artifactId>
-        <version>2.0.3</version>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>2.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <url>https://stash.forgerock.org/projects/OPENDJ/repos/opendj-sdk/browse</url>
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj-sdk.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj-sdk.git</developerConnection>
-        <tag>3.0.0</tag>
     </scm>
 
     <ciManagement>
@@ -152,7 +151,7 @@
             scp://community.internal.forgerock.com/var/www/vhosts/opendj.forgerock.org/httpdocs
         </site.distribution.url>
 
-        <opendj.sdk.version>3.0.0</opendj.sdk.version>
+        <opendj.sdk.version>3.0.1-SNAPSHOT</opendj.sdk.version>
         <i18n-framework.version>1.4.2</i18n-framework.version>
     </properties>
 


### PR DESCRIPTION
- Pulls in changes from FR's 3.0.1 release (we had this in our fork but hadn't previously built it).
- Upgrades the project to `wrensec-parent` 2.2.0 (for PGP signing)
- Updates `.wren-deploy.rc` to match latest project conventions