### PR TITLE
[Wren:DS #35] Search for Ports 50 at a Time Instead of 1,000

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/CliConstants.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/CliConstants.java
@@ -38,7 +38,7 @@ public final class CliConstants {
     public static final int DEFAULT_LDAP_CONNECT_TIMEOUT = 30000;
 
     /** Default value for incrementing port number. */
-    public static final int PORT_INCREMENT = 1000;
+    public static final int PORT_INCREMENT = 50;
 
     /** Default port number for the LDAP port. */
     public static final int DEFAULT_LDAP_PORT = 389;


### PR DESCRIPTION
I am not sure why it was previously necessary to skip over so many ports during a search. Since the RFC caps the port # range to 65,535, the old constant of 1,000 effectively limited the search space that the system would examine to no more than 64 ports (assuming the search started at <= 535).

Now, the search space is up to 1,310 ports.

This mitigates https://github.com/WrenSecurity/wrends/issues/35 for DS 3.0.